### PR TITLE
Refactor Google Analytics setup

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -24,7 +24,7 @@ kramdown:
   input: GFM
 highlighter: rouge
 
-analytics-google: 'UA-MYANALYTICS'
+analytics-google: 'G-P6YXLLEDMH'
 
 # if you don't want comments in your posts, set to false
 disqus: codemaxx

--- a/_includes/analytics-google.html
+++ b/_includes/analytics-google.html
@@ -1,11 +1,10 @@
-<!-- Google Analytics Tracking code -->
-<script type="text/javascript">
-    var _gaq = _gaq || [];
-    _gaq.push(['_setAccount', '{{ site.analytics-google }}']);
-    _gaq.push(['_trackPageview']);
-    (function() {
-        var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
-        ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
-        var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
-    })();
+<!-- Google Analytics 4 (GA4) Tracking code -->
+{% if site.analytics-google %}
+<script async src="https://www.googletagmanager.com/gtag/js?id={{ site.analytics-google }}"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', '{{ site.analytics-google }}');
 </script>
+{% endif %}

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,28 +1,4 @@
 
-<!-- Google Analytics 4 (new) -->
-
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-P6YXLLEDMH"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-
-  gtag('config', 'G-P6YXLLEDMH');
-</script>
-
-<!-- Universal Analytics (old) -->
-<script>
-  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-  })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-
-  ga('create', 'UA-77532305-1', 'auto');
-  ga('send', 'pageview');
-
-</script>
-
 <footer class="footer-main">
     © {{ site.name }} {{ site.time | date: '%Y' }} <a class="link" href="{{ site.url }}/feed.xml" target="_blank"><svg class="icon icon-rss"><use xlink:href="#icon-rss"></use></svg></a>
 

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -42,6 +42,7 @@ layout: compress
     </div>
 
     {% include icons.html %}
+    {% include analytics-google.html %}
 
 </body>
 </html>


### PR DESCRIPTION
## Summary
Clean up and refactor Google Analytics configuration.

## Changes
- Remove dead Universal Analytics code from footer
- Move GA4 tracking to dedicated analytics-google.html include
- Use config-based analytics ID instead of hardcoded value
- Include analytics from default.html layout (single source of truth)

## Why
- Removes legacy UA code that stopped working in July 2023
- Centralizes analytics config in _config.yml
- Cleaner separation of concerns