### PR TITLE
Add a concise README with overview and dev commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,27 @@
-# Blog about Experiences, Projects ,CTF Write-ups and other interesting stuff.
+# akashtrehan.com
+
+Source for my personal blog — experiences, projects, and CTF write-ups.
+
+**Live site:** [www.akashtrehan.com](https://www.akashtrehan.com)
+
+Built with [Jekyll](https://jekyllrb.com/) and deployed to GitHub Pages via GitHub
+Actions.
+
+## Local development
+
+Requires Ruby 3.4+ and [Bundler](https://bundler.io/).
+
+```sh
+bundle install    # install gems
+npm run dev       # serve at http://localhost:3000 with live reload
+```
+
+`npm run dev` wraps `bundle exec jekyll serve --livereload --drafts`, so Node isn't
+required to develop locally.
+
+## Build & test
+
+```sh
+npm run build     # build the site into _site/
+npm test          # build + link-check with html-proofer
+```


### PR DESCRIPTION
Replaces the single-line README with a concise overview of the project.

### Contents
- What the repo is + link to [www.akashtrehan.com](https://www.akashtrehan.com)
- **Local development** — Ruby 3.4+/Bundler prereqs and `npm run dev` (livereload on :3000)
- **Build & test** — `npm run build` and `npm test`

Kept intentionally short — just enough to get running.