### PR TITLE
Post footer, reading width, code blocks, and Tags/Archives polish

### DIFF
--- a/_includes/related-posts.html
+++ b/_includes/related-posts.html
@@ -98,8 +98,9 @@
                 {% if post.redirect_to %}
                   <i
                     class="fas fa-arrow-up-right-from-square external-link-icon ms-1"
-                    title="Opens an external site"
+                    aria-hidden="true"
                   ></i>
+                  <span class="sr-only"> (opens in a new tab)</span>
                 {% endif %}
               </h4>
               <div class="text-muted">

--- a/_includes/related-posts.html
+++ b/_includes/related-posts.html
@@ -1,0 +1,115 @@
+<!--
+  Local override of the theme's related-posts ("Further Reading") include.
+  Behaves exactly like the theme default (scores the other posts by shared
+  tags/categories and shows the top 3), but for posts with `redirect_to` it
+  links straight to the external target in a new tab and appends the same
+  external-link badge used on the listing cards, so external entries read
+  consistently everywhere they appear.
+-->
+
+<!-- Recommend the other 3 posts according to the tags and categories of the current post. -->
+
+<!-- The total size of related posts -->
+{% assign TOTAL_SIZE = 3 %}
+
+<!-- An random integer that bigger than 0 -->
+{% assign TAG_SCORE = 1 %}
+
+<!-- Equals to TAG_SCORE / {max_categories_hierarchy} -->
+{% assign CATEGORY_SCORE = 0.5 %}
+
+{% assign SEPARATOR = ':' %}
+
+{% assign match_posts = '' | split: '' %}
+
+{% for category in page.categories %}
+  {% assign match_posts = match_posts | push: site.categories[category] | uniq %}
+{% endfor %}
+
+{% for tag in page.tags %}
+  {% assign match_posts = match_posts | push: site.tags[tag] | uniq %}
+{% endfor %}
+
+{% assign match_posts = match_posts | reverse %}
+{% assign last_index = match_posts.size | minus: 1 %}
+{% assign score_list = '' | split: '' %}
+
+{% for i in (0..last_index) %}
+  {% assign post = match_posts[i] %}
+
+  {% if post.url == page.url %}
+    {% continue %}
+  {% endif %}
+
+  {% assign score = 0 %}
+
+  {% for tag in post.tags %}
+    {% if page.tags contains tag %}
+      {% assign score = score | plus: TAG_SCORE %}
+    {% endif %}
+  {% endfor %}
+
+  {% for category in post.categories %}
+    {% if page.categories contains category %}
+      {% assign score = score | plus: CATEGORY_SCORE %}
+    {% endif %}
+  {% endfor %}
+
+  {% if score > 0 %}
+    {% capture score_item %}{{ score }}{{ SEPARATOR }}{{ i }}{% endcapture %}
+    {% assign score_list = score_list | push: score_item %}
+  {% endif %}
+{% endfor %}
+
+{% assign index_list = '' | split: '' %}
+
+{% if score_list.size > 0 %}
+  {% assign score_list = score_list | sort | reverse %}
+  {% for entry in score_list limit: TOTAL_SIZE %}
+    {% assign index = entry | split: SEPARATOR | last %}
+    {% assign index_list = index_list | push: index %}
+  {% endfor %}
+{% endif %}
+
+{% assign relate_posts = '' | split: '' %}
+
+{% for index in index_list %}
+  {% assign i = index | to_integer %}
+  {% assign relate_posts = relate_posts | push: match_posts[i] %}
+{% endfor %}
+
+{% if relate_posts.size > 0 %}
+  <aside id="related-posts" aria-labelledby="related-label">
+    <h3 class="mb-4" id="related-label">
+      {{- site.data.locales[include.lang].post.relate_posts -}}
+    </h3>
+    <nav class="row row-cols-1 row-cols-md-2 row-cols-xl-3 g-4 mb-4">
+      {% for post in relate_posts %}
+        <article class="col">
+          <a
+            href="{% if post.redirect_to %}{{ post.redirect_to }}{% else %}{{ post.url | relative_url }}{% endif %}"
+            {% if post.redirect_to %}target="_blank" rel="noopener noreferrer"{% endif %}
+            class="post-preview card h-100"
+          >
+            <div class="card-body">
+              {% include datetime.html date=post.date lang=include.lang %}
+              <h4 class="pt-0 my-2">
+                {{ post.title }}
+                {% if post.redirect_to %}
+                  <i
+                    class="fas fa-arrow-up-right-from-square external-link-icon ms-1"
+                    title="Opens an external site"
+                  ></i>
+                {% endif %}
+              </h4>
+              <div class="text-muted">
+                <p>{% include post-summary.html %}</p>
+              </div>
+            </div>
+          </a>
+        </article>
+      {% endfor %}
+    </nav>
+  </aside>
+  <!-- #related-posts -->
+{% endif %}

--- a/_layouts/archives.html
+++ b/_layouts/archives.html
@@ -49,7 +49,7 @@ layout: page
         {{ post.date | date: df_strftime_m }}
       </span>
       {% if post.redirect_to %}
-        <a href="{{ post.redirect_to }}" target="_blank" rel="noopener noreferrer">{{ post.title }}<i class="fas fa-arrow-up-right-from-square external-link-icon ms-1" title="Opens an external site"></i></a>
+        <a href="{{ post.redirect_to }}" target="_blank" rel="noopener noreferrer">{{ post.title }}<i class="fas fa-arrow-up-right-from-square external-link-icon ms-1" aria-hidden="true"></i><span class="sr-only"> (opens in a new tab)</span></a>
       {% else %}
         <a href="{{ post.url | relative_url }}">{{ post.title }}</a>
       {% endif %}

--- a/_layouts/archives.html
+++ b/_layouts/archives.html
@@ -23,6 +23,10 @@ layout: page
 {% endfor %}
 {% assign keyed = keyed | sort | reverse %}
 
+<header class="listing-header">
+  <h1 class="listing-title">Archives</h1>
+</header>
+
 <div id="archives" class="pl-xl-3">
   {% for k in keyed %}
     {% assign idx = k | split: '@@@' | last | plus: 0 %}
@@ -44,7 +48,11 @@ layout: page
       <span class="date month small text-muted ms-1" data-ts="{{ ts }}" data-df="{{ df_dayjs_m }}">
         {{ post.date | date: df_strftime_m }}
       </span>
-      <a href="{{ post.url | relative_url }}">{{ post.title }}</a>
+      {% if post.redirect_to %}
+        <a href="{{ post.redirect_to }}" target="_blank" rel="noopener noreferrer">{{ post.title }}<i class="fas fa-arrow-up-right-from-square external-link-icon ms-1" title="Opens an external site"></i></a>
+      {% else %}
+        <a href="{{ post.url | relative_url }}">{{ post.title }}</a>
+      {% endif %}
     </li>
 
     {% if forloop.last %}</ul>{% endif %}

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -108,9 +108,9 @@ script_includes:
   </div>
 
   <div class="post-tail-wrapper text-muted">
-    <div class="d-flex justify-content-between align-items-center gap-3 mb-3">
-      <!-- categories -->
-      {% if page.categories.size > 0 %}
+    {% if page.categories.size > 0 %}
+      <div class="d-flex justify-content-between align-items-center gap-3 mb-3">
+        <!-- categories -->
         <div class="post-meta">
           <i class="far fa-folder-open fa-fw me-1"></i>
           {% for category in page.categories %}
@@ -118,37 +118,38 @@ script_includes:
             {%- unless forloop.last -%},{%- endunless -%}
           {% endfor %}
         </div>
-      {% endif %}
 
-      <!-- "Edit this post" link -->
-      {% include post-edit.html lang=lang %}
-    </div>
-
-    <!-- tags -->
-    {% if page.tags.size > 0 %}
-      <div class="post-tags">
-        <i class="fa fa-tags fa-fw me-1"></i>
-        {% for tag in page.tags %}
-          <a
-            href="{{ site.baseurl }}/tags/{{ tag | slugify | url_encode }}/"
-            class="post-tag post-tag-pill no-text-decoration"
-          >
-            {{- tag -}}
-          </a>
-        {% endfor %}
+        <!-- "Edit this post" link -->
+        {% include post-edit.html lang=lang %}
       </div>
     {% endif %}
 
+    <!-- tags + share on one row (stacks on mobile) -->
     <div
       class="
         post-tail-bottom
-        d-flex justify-content-between align-items-center mt-5 pb-2
+        d-flex flex-column flex-sm-row justify-content-between
+        align-items-start align-items-sm-center gap-3 mt-4 pb-2
       "
     >
-      <div class="license-wrapper"></div>
+      {% if page.tags.size > 0 %}
+        <div class="post-tags">
+          <i class="fa fa-tags fa-fw me-1"></i>
+          {% for tag in page.tags %}
+            <a
+              href="{{ site.baseurl }}/tags/{{ tag | slugify | url_encode }}/"
+              class="post-tag post-tag-pill no-text-decoration"
+            >
+              {{- tag -}}
+            </a>
+          {% endfor %}
+        </div>
+      {% endif %}
 
       {% include post-sharing.html lang=lang %}
     </div>
+
+    <div class="license-wrapper"></div>
     <!-- .post-tail-bottom -->
   </div>
   <!-- div.post-tail-wrapper -->

--- a/_layouts/tag.html
+++ b/_layouts/tag.html
@@ -39,7 +39,7 @@ panel_includes:
       {% assign post = page.posts[idx] %}
       <li class="d-flex justify-content-between px-md-3">
         {% if post.redirect_to %}
-          <a href="{{ post.redirect_to }}" target="_blank" rel="noopener noreferrer">{{ post.title }}<i class="fas fa-arrow-up-right-from-square external-link-icon ms-1" title="Opens an external site"></i></a>
+          <a href="{{ post.redirect_to }}" target="_blank" rel="noopener noreferrer">{{ post.title }}<i class="fas fa-arrow-up-right-from-square external-link-icon ms-1" aria-hidden="true"></i><span class="sr-only"> (opens in a new tab)</span></a>
         {% else %}
           <a href="{{ post.url | relative_url }}">{{ post.title }}</a>
         {% endif %}

--- a/_layouts/tag.html
+++ b/_layouts/tag.html
@@ -38,7 +38,11 @@ panel_includes:
       {% assign idx = k | split: '@@@' | last | plus: 0 %}
       {% assign post = page.posts[idx] %}
       <li class="d-flex justify-content-between px-md-3">
-        <a href="{{ post.url | relative_url }}">{{ post.title }}</a>
+        {% if post.redirect_to %}
+          <a href="{{ post.redirect_to }}" target="_blank" rel="noopener noreferrer">{{ post.title }}<i class="fas fa-arrow-up-right-from-square external-link-icon ms-1" title="Opens an external site"></i></a>
+        {% else %}
+          <a href="{{ post.url | relative_url }}">{{ post.title }}</a>
+        {% endif %}
         <span class="dash flex-grow-1"></span>
         {% include datetime.html date=post.date class='text-muted small text-nowrap' lang=lang %}
       </li>

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -389,6 +389,9 @@ $tn-max: 1140px;
 }
 
 /* Accent tag pills at the foot of the article */
+.post-tail-wrapper {
+  margin-top: 2.5rem;
+}
 .post-tags .post-tag-pill {
   border: 1px solid var(--accent-1);
   color: var(--accent-1) !important;

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -215,7 +215,7 @@ $tn-max: 1140px;
   display: none;
 }
 .tag-header {
-  margin: 0.5rem 0 1.5rem;
+  margin: 3rem 0 1.5rem;
 }
 .tag-title {
   display: flex;

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -524,6 +524,26 @@ div[class^='language-'] .code-header {
 #archives a:hover {
   color: var(--accent-2) !important;
 }
+/* Archives now carries the listing-page header; center the timeline in the
+   same 1080px column as the listing pages instead of stretching full width. */
+#archives {
+  max-width: 1080px;
+  margin-left: auto;
+  margin-right: auto;
+}
+#main-wrapper:has(#archives) .listing-header {
+  padding-left: 0;
+  padding-right: 0;
+}
+/* External-link badge in the archives / tag / related-posts listings. */
+#archives .external-link-icon,
+.tag-list .external-link-icon,
+#related-posts .external-link-icon {
+  font-size: 0.6em;
+  color: var(--text-muted-color);
+  vertical-align: 0.35em;
+  opacity: 0.85;
+}
 
 /* Restyle the TOC panel to match the accent theme (tocbot uses .is-active-link) */
 #toc-wrapper .toc-title {

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -388,6 +388,15 @@ $tn-max: 1140px;
   font-size: 0.88rem;
 }
 
+/* ---------- Post reading measure ---------- */
+/* The default article column runs ~100 chars/line, which is too wide for
+   comfortable prose. Constrain the article and its footer (Further Reading /
+   comments) to a readable measure, left-aligned; the TOC stays on the right. */
+.post-page,
+#main-wrapper:has(.post-page) #tail-wrapper {
+  max-width: 46rem;
+}
+
 /* Accent tag pills at the foot of the article */
 .post-tail-wrapper {
   margin-top: 2.5rem;
@@ -403,6 +412,37 @@ $tn-max: 1140px;
 .post-tags .post-tag-pill:hover {
   background: var(--accent-1);
   color: #fff !important;
+}
+
+/* ---------- Code blocks ---------- */
+/* Crisp monospace stack (no webfont dependency — resolves to Cascadia Code /
+   SF Mono / Consolas on modern systems). */
+code,
+kbd,
+samp,
+pre,
+.highlight,
+.highlight pre,
+.highlight code,
+td.rouge-code,
+div[class^='language-'] {
+  font-family: ui-monospace, 'JetBrains Mono', 'Cascadia Code', 'SFMono-Regular',
+    Menlo, Consolas, 'Liberation Mono', monospace;
+}
+/* Fenced blocks: rounded, clipped container with a divider under the header. */
+div[class^='language-'] {
+  border-radius: 12px;
+  overflow: hidden;
+}
+div[class^='language-'] .code-header {
+  border-bottom: 1px solid var(--language-border-color, rgba(0, 0, 0, 0.08));
+}
+/* Copy button picks up the accent on hover. */
+.code-header button:not([timeout]):hover {
+  background-color: var(--accent-soft) !important;
+}
+.code-header button:not([timeout]):hover i {
+  color: var(--accent-1) !important;
 }
 
 /* Restyle the TOC panel to match the accent theme (tocbot uses .is-active-link) */

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -445,6 +445,66 @@ div[class^='language-'] .code-header {
   color: var(--accent-1) !important;
 }
 
+/* ---------- Tags index + Archives pages ---------- */
+/* These pages already list everything, so the Recently Updated / Trending
+   Tags panel is redundant — drop it and use full width (like the listings). */
+#main-wrapper:has(#tags) #panel-wrapper,
+#main-wrapper:has(#archives) #panel-wrapper {
+  display: none;
+}
+#main-wrapper:has(#tags) > .container > .row > main,
+#main-wrapper:has(#tags) #tail-wrapper,
+#main-wrapper:has(#archives) > .container > .row > main,
+#main-wrapper:has(#archives) #tail-wrapper {
+  flex: 0 0 100%;
+  max-width: 100%;
+}
+/* Accent header for page-layout index pages (Tags / Archives) */
+.dynamic-title {
+  font-weight: 700;
+  letter-spacing: -0.02em;
+}
+.dynamic-title::after {
+  content: '';
+  display: block;
+  width: 54px;
+  height: 3px;
+  margin-top: 0.6rem;
+  border-radius: 3px;
+  background: var(--accent-grad);
+}
+/* Tags index chips: tighter, accent hover/focus, left-aligned on mobile. */
+#tags .tag {
+  line-height: 2.4rem;
+  margin-right: 0.5rem;
+  transition:
+    border-color 0.15s ease,
+    color 0.15s ease,
+    background 0.15s ease;
+}
+#tags .tag:hover,
+#tags .tag:focus-visible {
+  border-color: var(--accent-1) !important;
+  color: var(--accent-1);
+  background: var(--accent-soft);
+}
+#tags .tag span {
+  color: var(--accent-1);
+}
+@media (max-width: 991px) {
+  #tags {
+    justify-content: flex-start !important;
+  }
+}
+/* Archives: accent the timeline dots and post-title hover. */
+#archives .year::after,
+#archives a::before {
+  background-color: var(--accent-1) !important;
+}
+#archives a:hover {
+  color: var(--accent-2) !important;
+}
+
 /* Restyle the TOC panel to match the accent theme (tocbot uses .is-active-link) */
 #toc-wrapper .toc-title {
   color: var(--heading-color);

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -14,6 +14,20 @@
 
 /* append your custom style below */
 
+/* Visually-hidden helper for screen-reader-only text (not guaranteed to be in
+   the production Bootstrap bundle, so defined locally). */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 /* External-link indicator on post cards whose target leaves the site
    (posts with `redirect_to`). Kept subtle: muted colour, smaller than the
    title, and nudged up slightly so it reads as a superscript-style badge. */
@@ -411,6 +425,22 @@ $tn-max: 1140px;
 .post-tail-wrapper {
   margin-top: 2.5rem;
 }
+/* The `align-items-start` / `align-items-sm-center` and `ms-auto` Bootstrap
+   utilities are absent from the production CSS bundle, so set the row
+   alignment and the right-alignment of the share buttons explicitly. On mobile
+   the row stacks (column) and the share block sits below the tags full width;
+   from 576px up it's a single row with tags left and share pushed right. */
+.post-tail-bottom {
+  align-items: flex-start;
+}
+@media (min-width: 576px) {
+  .post-tail-bottom {
+    align-items: center;
+  }
+  .post-tail-bottom .share-wrapper {
+    margin-inline-start: auto;
+  }
+}
 .post-tags .post-tag-pill {
   border: 1px solid var(--accent-1);
   color: var(--accent-1) !important;
@@ -508,7 +538,7 @@ div[class^='language-'] .code-header {
   color: #fff;
 }
 #tags .tag span {
-  color: inherit;
+  color: inherit !important;
   opacity: 0.7;
 }
 @media (max-width: 991px) {

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -254,8 +254,18 @@ $tn-max: 1140px;
 }
 #all-tags .post-tag {
   margin: 0 0.5rem 0.6rem 0;
-  border-radius: 8px;
+  border-radius: 6px;
   font-size: 0.8rem;
+  border: 1px solid var(--accent-1) !important;
+  color: var(--accent-1) !important;
+  background: transparent;
+  transition:
+    background 0.15s ease,
+    color 0.15s ease;
+}
+#all-tags .post-tag:hover {
+  background: var(--accent-1);
+  color: #fff !important;
 }
 #all-tags .post-tag.tag-current {
   background: var(--accent-1);
@@ -459,8 +469,10 @@ div[class^='language-'] .code-header {
   flex: 0 0 100%;
   max-width: 100%;
 }
-/* Accent header for page-layout index pages (Tags / Archives) */
+/* Accent header for page-layout index pages (Tags / Archives) — matches the
+   listing-page header treatment (size + gradient underline). */
 .dynamic-title {
+  font-size: clamp(1.8rem, 3vw, 2.4rem);
   font-weight: 700;
   letter-spacing: -0.02em;
 }
@@ -473,23 +485,31 @@ div[class^='language-'] .code-header {
   border-radius: 3px;
   background: var(--accent-grad);
 }
-/* Tags index chips: tighter, accent hover/focus, left-aligned on mobile. */
+/* Tags index chips: match the site's 6px outline pill (like .card-tag /
+   .post-tag-pill) instead of the theme's rounded, shadowed chip. */
+#tags {
+  gap: 0.55rem;
+}
 #tags .tag {
-  line-height: 2.4rem;
-  margin-right: 0.5rem;
+  margin: 0 !important;
+  padding: 0.28rem 0.7rem;
+  line-height: 1.6;
+  border-radius: 6px;
+  border: 1px solid var(--accent-1) !important;
+  color: var(--accent-1);
+  box-shadow: none !important;
   transition:
-    border-color 0.15s ease,
-    color 0.15s ease,
-    background 0.15s ease;
+    background 0.15s ease,
+    color 0.15s ease;
 }
 #tags .tag:hover,
 #tags .tag:focus-visible {
-  border-color: var(--accent-1) !important;
-  color: var(--accent-1);
-  background: var(--accent-soft);
+  background: var(--accent-1);
+  color: #fff;
 }
 #tags .tag span {
-  color: var(--accent-1);
+  color: inherit;
+  opacity: 0.7;
 }
 @media (max-width: 991px) {
   #tags {


### PR DESCRIPTION
Design polish for the post footer, reading width, code blocks, and the Tags/Archives index pages. Before shots are from the live site; after shots from a local production build.

## Post footer — tags + share on one row
Tags (left) and share buttons (right) now share a single row that stacks on mobile, instead of the share buttons being pushed to the far right on their own line. The empty categories row is skipped when a post has no categories, and the oversized top gap (96px) is reduced.

| Before | After |
|---|---|
| ![before](https://github.com/CodeMaxx/CodeMaxx.github.io/releases/download/pr-assets/pp-before-footer.png) | ![after](https://github.com/CodeMaxx/CodeMaxx.github.io/releases/download/pr-assets/pp-after-footer.png) |

## Post reading width (af2.9)
The article column ran ~100 characters per line. Constrained the article + its footer/Further Reading to a ~46rem reading measure (left-aligned, TOC alongside) for comfortable prose.

| Before | After |
|---|---|
| ![before](https://github.com/CodeMaxx/CodeMaxx.github.io/releases/download/pr-assets/pp-before-reading.png) | ![after](https://github.com/CodeMaxx/CodeMaxx.github.io/releases/download/pr-assets/pp-after-reading.png) |

## Code blocks (af2.27)
Crisp monospace stack (Cascadia/SF Mono/Consolas via `ui-monospace` — no webfont), a rounded/clipped container with a divider under the header, and an accent copy button on hover. (A full dark-terminal look would need a syntax-palette swap — happy to do that separately if you want it.)

| Before | After |
|---|---|
| ![before](https://github.com/CodeMaxx/CodeMaxx.github.io/releases/download/pr-assets/pp-before-code.png) | ![after](https://github.com/CodeMaxx/CodeMaxx.github.io/releases/download/pr-assets/pp-after-code.png) |

## Tags index (af2.29)
Accent header, full width (dropped the redundant Recently Updated / Trending Tags panel — the page already lists every tag), tighter chips with accent hover/focus, left-aligned on mobile.

| Before | After |
|---|---|
| ![before](https://github.com/CodeMaxx/CodeMaxx.github.io/releases/download/pr-assets/pp-before-tags.png) | ![after](https://github.com/CodeMaxx/CodeMaxx.github.io/releases/download/pr-assets/pp-after-tags.png) |

## Archives (af2.29 + follow-up)
Added the listing-page header (`Archives` + gradient underline — it was the only main page with no title), centred the timeline in the same 1080px column as the Blog / Write-ups / Projects listings (it previously stretched full width, leaving the narrow date/title list lopsided with a big empty right column), accent-coloured the timeline dots + post-title hovers, dropped the redundant Recently Updated / Trending Tags panel, and added the external-link badge to `redirect_to` entries.

| Before | After |
|---|---|
| ![before](https://github.com/CodeMaxx/CodeMaxx.github.io/releases/download/pr-assets/pp-before-archives.png) | ![after](https://github.com/CodeMaxx/CodeMaxx.github.io/releases/download/pr-assets/pr68-archives-after.png) |

## External-link badge — now on every post listing
The ↗ badge that already marked external (`redirect_to`) posts on the listing cards, landing page, and search results now also appears on the Archives timeline, the individual tag pages, and the Further Reading (related-posts) cards, and those links open in a new tab (with `aria-hidden` icon + a visually-hidden "opens in a new tab" note) — so external entries read consistently wherever posts are listed. (Tag pages / Further Reading will surface it once the legacy `tag:` front-matter is normalised to `tags:`.) Shown below on the Archives page: the three external entries (HackInOut, Machine Leaning, Graphics) gain the ↗ badge.

| Before (no badge) | After (↗ badge) |
|---|---|
| ![before](https://github.com/CodeMaxx/CodeMaxx.github.io/releases/download/pr-assets/pp-before-archives.png) | ![after](https://github.com/CodeMaxx/CodeMaxx.github.io/releases/download/pr-assets/pr68-archives-after.png) |

---
_Screenshots are hosted as `pr-assets` release assets (GitHub CDN), not committed to the repo._


