### PR TITLE
Normalize post tag taxonomy and refresh host proof

### DIFF
--- a/_posts/2016-05-10-SymEngine.md
+++ b/_posts/2016-05-10-SymEngine.md
@@ -2,10 +2,10 @@
 title: "SymEngine"
 layout: post
 date: 2016-05-9 8:10
-tag:
+tags:
 - Open Source
-- Mathematics
 - Cpp
+- Computer Algebra
 projects: true
 star: true
 description: "Symbolic Computation C++ Library"

--- a/_posts/2016-05-10-sympy.md
+++ b/_posts/2016-05-10-sympy.md
@@ -3,10 +3,10 @@ title: "SymPy"
 layout: post
 date: 2016-05-10 8:15
 image: /assets/images/sympy-wide.png
-tag:
+tags:
 - Open Source
-- Mathematics
 - Python
+- Computer Algebra
 projects: true
 description: "Symbolic Computation Python Library"
 ---
@@ -23,4 +23,3 @@ A short description of [My Pull Requests](https://github.com/sympy/sympy/pulls/C
 2. [PR #10721](https://github.com/sympy/sympy/pull/10721 )(**Merged**) - Fixed typo in documentation of `asech` function.
 
 3. [Issue #10717](https://github.com/sympy/sympy/issues/10717 )(**Open**) - Issue about missing `acsch` function which I fix in [PR #10714](https://github.com/sympy/sympy/pull/10714).
-

--- a/_posts/2016-05-10-wptview.md
+++ b/_posts/2016-05-10-wptview.md
@@ -3,10 +3,10 @@ title: "wptview"
 layout: post
 date: 2016-05-10 8:20
 image: /assets/images/mozilla-wide.png
-tag:
+tags:
 - Open Source
-- Web Developement
-- Angular JS
+- Web Development
+- AngularJS
 projects: true
 description: "Web Platform Test Viewer"
 ---

--- a/_posts/2016-05-16-writeup-infosec_institute_n00b_ctf-level1.md
+++ b/_posts/2016-05-16-writeup-infosec_institute_n00b_ctf-level1.md
@@ -4,8 +4,9 @@ layout: post
 permalink: /writeups/Infosec_Institute_n00b_ctf/level1/
 date: 2016-05-16 8:10
 image: /assets/images/InfosecInstin00b/yoda1-wide.png
-tag:
-- Web
+tags:
+- CTF
+- Web Security
 - Infosec Institute n00b CTF
 writeup: true
 star: false

--- a/_posts/2016-05-16-writeup-infosec_institute_n00b_ctf-level2.md
+++ b/_posts/2016-05-16-writeup-infosec_institute_n00b_ctf-level2.md
@@ -4,8 +4,9 @@ layout: post
 permalink: /writeups/Infosec_Institute_n00b_ctf/level2/
 date: 2016-05-16 8:10
 image: /assets/images/InfosecInstin00b/desc2-wide.png
-tag:
-- Web
+tags:
+- CTF
+- Web Security
 - Infosec Institute n00b CTF
 writeup: true
 star: false

--- a/_posts/2016-05-16-writeup-infosec_institute_n00b_ctf-level3.md
+++ b/_posts/2016-05-16-writeup-infosec_institute_n00b_ctf-level3.md
@@ -4,8 +4,9 @@ layout: post
 permalink: /writeups/Infosec_Institute_n00b_ctf/level3/
 date: 2016-05-16 8:15
 image: /assets/images/InfosecInstin00b/qr3-wide.png
-tag:
-- Web
+tags:
+- CTF
+- Web Security
 - Infosec Institute n00b CTF
 writeup: true
 star: false

--- a/_posts/2016-05-31-writeup-overthewire-bandit-level00.md
+++ b/_posts/2016-05-31-writeup-overthewire-bandit-level00.md
@@ -4,10 +4,10 @@ layout: post
 permalink: /writeups/OverTheWire/Bandit/level00/
 date: 2016-05-31 01:16:51 +0530
 image: /assets/images/OverTheWire/Bandit/hero-level0.png
-tag:
+tags:
 - Bandit
 - OverTheWire
-- Wargames
+- SSH
 writeup: true
 star: false
 points:

--- a/_posts/2016-05-31-writeup-overthewire-bandit-level01.md
+++ b/_posts/2016-05-31-writeup-overthewire-bandit-level01.md
@@ -4,10 +4,10 @@ layout: post
 permalink: /writeups/OverTheWire/Bandit/level01/
 date: 2016-05-31 01:16:51 +0530
 image: /assets/images/OverTheWire/Bandit/hero-level1.png
-tag:
+tags:
 - Bandit
 - OverTheWire
-- Wargames
+- Shell
 writeup: true
 star: false
 points:

--- a/_posts/2016-05-31-writeup-overthewire-bandit-level02.md
+++ b/_posts/2016-05-31-writeup-overthewire-bandit-level02.md
@@ -4,10 +4,10 @@ layout: post
 permalink: /writeups/OverTheWire/Bandit/level02/
 date: 2016-05-31 01:16:51 +0530
 image: /assets/images/OverTheWire/Bandit/hero-level2.png
-tag:
+tags:
 - Bandit
 - OverTheWire
-- Wargames
+- Shell
 writeup: true
 star: false
 points:

--- a/_posts/2016-05-31-writeup-overthewire-bandit-level03.md
+++ b/_posts/2016-05-31-writeup-overthewire-bandit-level03.md
@@ -4,10 +4,10 @@ layout: post
 permalink: /writeups/OverTheWire/Bandit/level03/
 date: 2016-05-31 01:16:51 +0530
 image: /assets/images/OverTheWire/Bandit/hero-level3.png
-tag:
+tags:
 - Bandit
 - OverTheWire
-- Wargames
+- Shell
 writeup: true
 star: false
 points:

--- a/_posts/2016-05-31-writeup-overthewire-bandit-level04.md
+++ b/_posts/2016-05-31-writeup-overthewire-bandit-level04.md
@@ -4,10 +4,10 @@ layout: post
 permalink: /writeups/OverTheWire/Bandit/level04/
 date: 2016-05-31 01:16:51 +0530
 image: /assets/images/OverTheWire/Bandit/hero-level4.png
-tag:
+tags:
 - Bandit
 - OverTheWire
-- Wargames
+- File Analysis
 writeup: true
 star: false
 points:

--- a/_posts/2016-05-31-writeup-overthewire-bandit-level05.md
+++ b/_posts/2016-05-31-writeup-overthewire-bandit-level05.md
@@ -4,10 +4,10 @@ layout: post
 permalink: /writeups/OverTheWire/Bandit/level05/
 date: 2016-05-31 01:16:51 +0530
 image: /assets/images/OverTheWire/Bandit/hero-level5.png
-tag:
+tags:
 - Bandit
 - OverTheWire
-- Wargames
+- Shell
 writeup: true
 star: false
 points:

--- a/_posts/2016-05-31-writeup-overthewire-bandit-level06.md
+++ b/_posts/2016-05-31-writeup-overthewire-bandit-level06.md
@@ -4,10 +4,10 @@ layout: post
 permalink: /writeups/OverTheWire/Bandit/level06/
 date: 2016-05-31 01:16:51 +0530
 image: /assets/images/OverTheWire/Bandit/hero-level6.png
-tag:
+tags:
 - Bandit
 - OverTheWire
-- Wargames
+- Shell
 writeup: true
 star: false
 points:

--- a/_posts/2016-05-31-writeup-overthewire-bandit-level07.md
+++ b/_posts/2016-05-31-writeup-overthewire-bandit-level07.md
@@ -4,10 +4,10 @@ layout: post
 permalink: /writeups/OverTheWire/Bandit/level07/
 date: 2016-05-31 01:16:51 +0530
 image: /assets/images/OverTheWire/Bandit/hero-level7.png
-tag:
+tags:
 - Bandit
 - OverTheWire
-- Wargames
+- Text Processing
 writeup: true
 star: false
 points:

--- a/_posts/2016-05-31-writeup-overthewire-bandit-level08.md
+++ b/_posts/2016-05-31-writeup-overthewire-bandit-level08.md
@@ -4,10 +4,10 @@ layout: post
 permalink: /writeups/OverTheWire/Bandit/level08/
 date: 2016-05-31 01:16:51 +0530
 image: /assets/images/OverTheWire/Bandit/hero-level8.png
-tag:
+tags:
 - Bandit
 - OverTheWire
-- Wargames
+- Text Processing
 writeup: true
 star: false
 points:

--- a/_posts/2016-05-31-writeup-overthewire-bandit-level09.md
+++ b/_posts/2016-05-31-writeup-overthewire-bandit-level09.md
@@ -4,10 +4,10 @@ layout: post
 permalink: /writeups/OverTheWire/Bandit/level09/
 date: 2016-05-31 01:16:51 +0530
 image: /assets/images/OverTheWire/Bandit/hero-level9.png
-tag:
+tags:
 - Bandit
 - OverTheWire
-- Wargames
+- File Analysis
 writeup: true
 star: false
 points:

--- a/_posts/2016-05-31-writeup-overthewire-bandit-level10.md
+++ b/_posts/2016-05-31-writeup-overthewire-bandit-level10.md
@@ -4,10 +4,10 @@ layout: post
 permalink: /writeups/OverTheWire/Bandit/level10/
 date: 2016-05-31 00:41:51 +0530
 image: /assets/images/OverTheWire/Bandit/hero-level10.png
-tag:
+tags:
 - Bandit
 - OverTheWire
-- Wargames
+- Encoding
 writeup: true
 star: false
 points:

--- a/_posts/2016-05-31-writeup-overthewire-bandit-level11.md
+++ b/_posts/2016-05-31-writeup-overthewire-bandit-level11.md
@@ -4,10 +4,10 @@ layout: post
 permalink: /writeups/OverTheWire/Bandit/level11/
 date: 2016-05-31 00:41:51 +0530
 image: /assets/images/OverTheWire/Bandit/hero-level11.png
-tag:
+tags:
 - Bandit
 - OverTheWire
-- Wargames
+- Encoding
 writeup: true
 star: false
 points:

--- a/_posts/2016-05-31-writeup-overthewire-bandit-level12.md
+++ b/_posts/2016-05-31-writeup-overthewire-bandit-level12.md
@@ -4,10 +4,10 @@ layout: post
 permalink: /writeups/OverTheWire/Bandit/level12/
 date: 2016-05-31 00:41:51 +0530
 image: /assets/images/OverTheWire/Bandit/hero-level12.png
-tag:
+tags:
 - Bandit
 - OverTheWire
-- Wargames
+- File Analysis
 writeup: true
 star: false
 points:

--- a/_posts/2016-05-31-writeup-overthewire-bandit-level13.md
+++ b/_posts/2016-05-31-writeup-overthewire-bandit-level13.md
@@ -4,10 +4,10 @@ layout: post
 permalink: /writeups/OverTheWire/Bandit/level13/
 date: 2016-05-31 00:41:51 +0530
 image: /assets/images/OverTheWire/Bandit/hero-level13.png
-tag:
+tags:
 - Bandit
 - OverTheWire
-- Wargames
+- SSH
 writeup: true
 star: false
 points:

--- a/_posts/2016-05-31-writeup-overthewire-bandit-level14.md
+++ b/_posts/2016-05-31-writeup-overthewire-bandit-level14.md
@@ -4,10 +4,10 @@ layout: post
 permalink: /writeups/OverTheWire/Bandit/level14/
 date: 2016-05-31 00:41:51 +0530
 image: /assets/images/OverTheWire/Bandit/hero-level14.png
-tag:
+tags:
 - Bandit
 - OverTheWire
-- Wargames
+- Networking
 writeup: true
 star: false
 points:

--- a/_posts/2016-05-31-writeup-overthewire-bandit-level15.md
+++ b/_posts/2016-05-31-writeup-overthewire-bandit-level15.md
@@ -4,10 +4,10 @@ layout: post
 permalink: /writeups/OverTheWire/Bandit/level15/
 date: 2016-05-31 04:37:00 +0530
 image: /assets/images/OverTheWire/Bandit/hero-level15.png
-tag:
+tags:
 - Bandit
 - OverTheWire
-- Wargames
+- Networking
 writeup: true
 star: false
 points:

--- a/_posts/2016-05-31-writeup-overthewire-bandit-level16.md
+++ b/_posts/2016-05-31-writeup-overthewire-bandit-level16.md
@@ -4,10 +4,10 @@ layout: post
 permalink: /writeups/OverTheWire/Bandit/level16/
 date: 2016-05-31 04:37:00 +0530
 image: /assets/images/OverTheWire/Bandit/hero-level16.png
-tag:
+tags:
 - Bandit
 - OverTheWire
-- Wargames
+- Networking
 writeup: true
 star: false
 points:

--- a/_posts/2016-05-31-writeup-overthewire-bandit-level17.md
+++ b/_posts/2016-05-31-writeup-overthewire-bandit-level17.md
@@ -4,10 +4,10 @@ layout: post
 permalink: /writeups/OverTheWire/Bandit/level17/
 date: 2016-05-31 04:37:00 +0530
 image: /assets/images/OverTheWire/Bandit/hero-level17.png
-tag:
+tags:
 - Bandit
 - OverTheWire
-- Wargames
+- Text Processing
 writeup: true
 star: false
 points:

--- a/_posts/2016-06-02-writeup-overthewire-bandit-level18.md
+++ b/_posts/2016-06-02-writeup-overthewire-bandit-level18.md
@@ -4,10 +4,10 @@ layout: post
 permalink: /writeups/OverTheWire/Bandit/level18/
 date: 2016-06-02 22:45:50 +0530
 image: /assets/images/OverTheWire/Bandit/hero-level18.png
-tag:
+tags:
 - Bandit
 - OverTheWire
-- Wargames
+- SSH
 writeup: true
 star: false
 points:

--- a/_posts/2016-06-02-writeup-overthewire-bandit-level19.md
+++ b/_posts/2016-06-02-writeup-overthewire-bandit-level19.md
@@ -4,10 +4,10 @@ layout: post
 permalink: /writeups/OverTheWire/Bandit/level19/
 date: 2016-06-02 22:45:50 +0530
 image: /assets/images/OverTheWire/Bandit/hero-level19.png
-tag:
+tags:
 - Bandit
 - OverTheWire
-- Wargames
+- Privilege Escalation
 writeup: true
 star: false
 points:

--- a/_posts/2016-06-07-importance-of-quotes-in-terminal.md
+++ b/_posts/2016-06-07-importance-of-quotes-in-terminal.md
@@ -3,9 +3,9 @@ title: "Importance of quotes in Terminal"
 layout: post
 date: 2016-06-07 11:00
 image: /assets/images/quotes-hero.png
-tag:
-- Unix
-- Terminal
+tags:
+- Linux
+- Shell
 - Tutorial
 blog: true
 description: "Single vs double vs no quotes — how shell expansion changes everything"

--- a/_posts/2016-06-07-writeup-backdoorctf16-0intro16.md
+++ b/_posts/2016-06-07-writeup-backdoorctf16-0intro16.md
@@ -4,10 +4,10 @@ layout: post
 permalink: /writeups/backdoorctf16/0intro16/
 date: 2016-06-07 07:44:01 +0530
 image: /assets/images/backdoorctf16/hero-intro16.png
-tag:
-- BackdoorCTF2016
-- Miscellaneous
-- Backdoor
+tags:
+- BackdoorCTF
+- CTF
+- OSINT
 writeup: true
 star: false
 points: 10

--- a/_posts/2016-06-07-writeup-backdoorctf16-1jigsaw.md
+++ b/_posts/2016-06-07-writeup-backdoorctf16-1jigsaw.md
@@ -4,10 +4,10 @@ layout: post
 permalink: /writeups/backdoorctf16/1jigsaw/
 date: 2016-06-07 07:44:01 +0530
 image: /assets/images/backdoorctf16/hero-jigsaw.png
-tag:
-- BackdoorCTF2016
-- Miscellaneous
-- Backdoor
+tags:
+- BackdoorCTF
+- CTF
+- Forensics
 writeup: true
 star: false
 points: 150

--- a/_posts/2016-06-07-writeup-backdoorctf16-2isolve.md
+++ b/_posts/2016-06-07-writeup-backdoorctf16-2isolve.md
@@ -4,10 +4,10 @@ layout: post
 permalink: /writeups/backdoorctf16/2isolve/
 date: 2016-06-07 07:44:01 +0530
 image: /assets/images/backdoorctf16/hero-isolve.png
-tag:
-- BackdoorCTF2016
-- Exploitation
-- Backdoor
+tags:
+- BackdoorCTF
+- CTF
+- Python
 writeup: true
 star: false
 points: 200

--- a/_posts/2016-06-07-writeup-backdoorctf16-3imagelover.md
+++ b/_posts/2016-06-07-writeup-backdoorctf16-3imagelover.md
@@ -4,10 +4,10 @@ layout: post
 permalink: /writeups/backdoorctf16/3imagelover/
 date: 2016-06-07 07:44:01 +0530
 image: /assets/images/backdoorctf16/hero-imagelover.png
-tag:
-- BackdoorCTF2016
-- Web
-- Backdoor
+tags:
+- BackdoorCTF
+- CTF
+- Web Security
 writeup: true
 star: false
 points: 70

--- a/_posts/2016-06-08-writeup-backdoorctf16-4busybee.md
+++ b/_posts/2016-06-08-writeup-backdoorctf16-4busybee.md
@@ -4,10 +4,10 @@ layout: post
 permalink: /writeups/backdoorctf16/4busybee/
 date: 2016-06-08 22:59:14 +0530
 image: /assets/images/backdoorctf16/hero-busybee.png
-tag:
-- BackdoorCTF2016
+tags:
+- BackdoorCTF
+- CTF
 - Forensics
-- Backdoor
 writeup: true
 star: false
 points: 150

--- a/_posts/2016-06-09-writeup-backdoorctf16-5debug.md
+++ b/_posts/2016-06-09-writeup-backdoorctf16-5debug.md
@@ -4,10 +4,10 @@ layout: post
 permalink: /writeups/backdoorctf16/5debug/
 date: 2016-06-09 17:14:16 +0530
 image: /assets/images/backdoorctf16/hero-debug.png
-tag:
-- BackdoorCTF2016
-- Reversing
-- Backdoor
+tags:
+- BackdoorCTF
+- CTF
+- Reverse Engineering
 writeup: true
 star: false
 points: 30
@@ -53,4 +53,3 @@ This as expected printed out the flag!
 ![Flag Printed](/assets/images/backdoorctf16/debug_flag.png)
 
 **Go through other [writeups](/writeups/) for more such fun challenges.**
-

--- a/_posts/2016-06-10-writeup-backdoorctf16-6enter-the-matrix.md
+++ b/_posts/2016-06-10-writeup-backdoorctf16-6enter-the-matrix.md
@@ -4,10 +4,10 @@ layout: post
 permalink: /writeups/backdoorctf16/6enter-the-matrix/
 date: 2016-06-10 06:02:36 +0530
 image: /assets/images/backdoorctf16/hero-enter-the-matrix.png
-tag:
-- BackdoorCTF2016
-- Pwning
-- Backdoor
+tags:
+- BackdoorCTF
+- CTF
+- Binary Exploitation
 writeup: true
 star: false
 points: 350

--- a/_posts/2016-06-15-different-kinds-of-executables.md
+++ b/_posts/2016-06-15-different-kinds-of-executables.md
@@ -3,10 +3,9 @@ title: "Knowing your Binary!"
 layout: post
 date: 2016-06-15 00:00
 image: /assets/images/re-wide.png
-tag:
-- Executable
-- ELF v/s Mach-o v/s PE
-- Reversing
+tags:
+- Executable Formats
+- Reverse Engineering
 - Tutorial
 blog: true
 description: "ELF, Mach-O, PE — decoding every word the file command throws at you"

--- a/_posts/2016-07-04-owasp-zsc.md
+++ b/_posts/2016-07-04-owasp-zsc.md
@@ -3,7 +3,7 @@ title: "OWASP ZSC"
 layout: post
 date: 2016-07-04 8:20
 image: /assets/images/owasp-wide.png
-tag:
+tags:
 - Open Source
 - Security
 - OWASP

--- a/_posts/2016-07-07-how-to-crack-wifi-password.md
+++ b/_posts/2016-07-07-how-to-crack-wifi-password.md
@@ -3,10 +3,10 @@ title: "How to crack Wifi Passwords"
 layout: post
 date: 2016-07-07 11:00
 image: /assets/images/wifi_crack/wifi-crack-wide.png
-tag:
-- Wifi
-- Hack
-- Tutorial
+tags:
+- Security
+- Wi-Fi
+- WPA2
 blog: true
 description: "Capturing the WPA2 four-way handshake and brute-forcing it with Aircrack-ng"
 ---
@@ -36,4 +36,3 @@ It’s tough to say how long it would take to crack a password in this way. For 
 P.S. - For Educational purposes only.
 
 **Update:** Here's a nice step-by-step description (with commands) of how to do this -> [Wifi Cracking](https://github.com/brannondorsey/wifi-cracking)
-

--- a/_posts/2016-08-10-terminal-commands-for-everyone.md
+++ b/_posts/2016-08-10-terminal-commands-for-everyone.md
@@ -2,9 +2,9 @@
 title: "Awesome Terminal Commands"
 layout: post
 date: 2016-08-10 00:00
-tag:
-- Unix
-- Terminal
+tags:
+- Linux
+- Shell
 - Tutorial
 blog: true
 redirect_to: https://github.com/CodeMaxx/Awesome-Terminal-Commands

--- a/_posts/2016-11-03-did-i-execute.md
+++ b/_posts/2016-11-03-did-i-execute.md
@@ -3,9 +3,9 @@ title: "Did I Execute?"
 layout: post
 date: 2016-11-03 11:00
 image: /assets/images/terminal-hero.png
-tag:
-- Unix
-- Terminal
+tags:
+- Linux
+- Shell
 - Tutorial
 blog: true
 description: "The subtle difference between ;, && and || that most terminal users get wrong"

--- a/_posts/2017-05-03-printing-emojis-on-terminal.md
+++ b/_posts/2017-05-03-printing-emojis-on-terminal.md
@@ -3,10 +3,11 @@ title: "Printing Emojis on Terminal"
 layout: post
 date: 2017-05-03 9:00
 image: /assets/images/emoji/printing-emojis-hero.png
-tag:
-- Tutorial
-- Terminal
+tags:
+- Cpp
 - Unicode
+- Shell
+- Tutorial
 blog: true
 description: "C++ code for printing emojis to terminal"
 ---

--- a/_posts/2017-06-12-writeup-pwnablekr_todders_bottle.md
+++ b/_posts/2017-06-12-writeup-pwnablekr_todders_bottle.md
@@ -4,10 +4,10 @@ layout: post
 permalink: /writeups/pwnablekr_todders_bottle/
 date: 2017-06-12 02:41:00 -0700
 image: /assets/images/pwnablekr-wide.png
-tag:
-- Pwning
-- Hacking
+tags:
+- Pwnable.kr
 - CTF
+- Binary Exploitation
 writeup: true
 star: false
 points: ∞

--- a/_posts/2017-08-03-writeup-bugs_bunny_rev75.md
+++ b/_posts/2017-08-03-writeup-bugs_bunny_rev75.md
@@ -4,10 +4,10 @@ layout: post
 permalink: /writeups/bugs_bunny_rev75/
 date: 2017-08-03 02:37:41 +0530
 image: /assets/images/bugs_bunny-wide.png
-tag:
-- Reversing
-- Hacking
+tags:
+- Bugs Bunny CTF
 - CTF
+- Reverse Engineering
 writeup: true
 star: false
 points: 75

--- a/_posts/2017-08-05-writeup-runesec_evecodesbetter.md
+++ b/_posts/2017-08-05-writeup-runesec_evecodesbetter.md
@@ -4,10 +4,10 @@ layout: post
 permalink: /writeups/runesec_evecodesbetter/
 date: 2017-08-05 19:33:38 +0530
 image: /assets/images/evecodesbetter/runesec-wide.png
-tag:
-- Crypto
-- Hacking
+tags:
+- RuneSec CTF
 - CTF
+- Cryptography
 writeup: true
 star: false
 points: 400

--- a/_posts/2017-08-25-csec-binary-exploitation-1.md
+++ b/_posts/2017-08-25-csec-binary-exploitation-1.md
@@ -3,7 +3,7 @@ title: "CSec - Binary Exploitation 1"
 layout: post
 date: 2017-08-25 00:00
 image: /assets/images/csec-wide.png
-tag:
+tags:
 - Binary Exploitation
 - Video
 - Tutorial

--- a/_posts/2017-10-18-Ubisoft-GameJam-Winners.md
+++ b/_posts/2017-10-18-Ubisoft-GameJam-Winners.md
@@ -3,12 +3,11 @@ title: "Won Ubisoft GameJam 2017"
 layout: post
 date: 2017-10-18 11:00
 image: /assets/images/ubisoft-wide.png
-tag:
+tags:
 - Hackathon
-- Ubisoft
-- Development
-- GameJam
+- Game Development
 - Unity
+- Ubisoft Game Jam
 blog: true
 description: "How we built a 3D Unity game in 30 hours and won Ubisoft's GameJam 2017"
 ---

--- a/_posts/2017-10-18-writeup-backdoorctf17-1ecb.md
+++ b/_posts/2017-10-18-writeup-backdoorctf17-1ecb.md
@@ -4,10 +4,10 @@ layout: post
 permalink: /writeups/backdoorctf17/1ecb/
 date: 2017-10-18 23:47:32 +0530
 image: /assets/images/backdoorctf17/hero-ecb.png
-tag:
-- BackdoorCTF2017
-- Crypto
-- Backdoor
+tags:
+- BackdoorCTF
+- CTF
+- Cryptography
 writeup: true
 star: false
 points: 150

--- a/_posts/2017-10-19-writeup-backdoorctf17-2funsignals.md
+++ b/_posts/2017-10-19-writeup-backdoorctf17-2funsignals.md
@@ -4,10 +4,10 @@ layout: post
 permalink: /writeups/backdoorctf17/2funsignals/
 date: 2017-10-19 01:23:49 +0530
 image: /assets/images/backdoorctf17/hero-funsignals.png
-tag:
-- BackdoorCTF2017
-- Pwn
-- Backdoor
+tags:
+- BackdoorCTF
+- CTF
+- Binary Exploitation
 writeup: true
 star: false
 points: 250

--- a/_posts/2017-11-08-csec-binary-exploitation-2.md
+++ b/_posts/2017-11-08-csec-binary-exploitation-2.md
@@ -3,7 +3,7 @@ title: "CSec - Binary Exploitation 2"
 layout: post
 date: 2017-11-08 00:00
 image: /assets/images/csec-wide.png
-tag:
+tags:
 - Binary Exploitation
 - Video
 - Tutorial

--- a/_posts/2017-12-13-indexing-schemes.md
+++ b/_posts/2017-12-13-indexing-schemes.md
@@ -3,10 +3,10 @@ title: "Hacking Postgres Internals - Indexing Schemes for Data Recording Systems
 layout: post
 date: 2017-12-13 8:20
 image: /assets/images/database-wide.png
-tag:
+tags:
 - Databases
+- PostgreSQL
 - C
-- Postgres
 projects: true
 star: true
 description: "Implementing stepped-merge indexes inside PostgreSQL's C codebase from a 1997 research paper"

--- a/_posts/2017-12-13-project-ditch.md
+++ b/_posts/2017-12-13-project-ditch.md
@@ -3,10 +3,10 @@ title: "Database course project and how I almost ditched it!"
 layout: post
 date: 2017-12-12 8:20
 image: /assets/images/database-wide.png
-tag:
+tags:
 - Databases
+- PostgreSQL
 - C
-- Postgres
 blog: true
 description: "We nearly quit our Postgres internals project — our professor's passion talk changed everything"
 ---
@@ -63,4 +63,3 @@ The [code for this project](https://github.com/CodeMaxx/postgres-with-stepped-me
 
 <br>
 Do check out other [projects](../../projects), [my blog](../../blog) or [my write-ups](../../writeups) for various CTFs.
-

--- a/_posts/2017-12-23-right-way-to-use-sublime-text.md
+++ b/_posts/2017-12-23-right-way-to-use-sublime-text.md
@@ -3,9 +3,10 @@ title: "The Right way to use Sublime Text"
 layout: post
 date: 2017-12-23 00:00
 image: /assets/images/sublime-wide.png
-tag:
+tags:
 - Productivity
-- Text Editor
+- Developer Tools
+- Sublime Text
 - Tutorial
 blog: true
 description: "11 keyboard shortcuts that turn Sublime Text into a productivity beast"

--- a/_posts/2017-12-31-graphics.md
+++ b/_posts/2017-12-31-graphics.md
@@ -2,11 +2,10 @@
 title: "Graphics - Modelling, Rendering and Animation"
 layout: post
 date: 2017-12-31 8:15
-tag:
-- Graphics
+tags:
+- Computer Graphics
 - Animation
-- Open GL
-- Modelling
+- OpenGL
 projects: true
 redirect_to: https://github.com/CodeMaxx/CS475-Graphics
 description: "OpenGL course project covering 3D modelling, rendering pipelines, and animation"

--- a/_posts/2017-12-31-writeup-machine_learning.md
+++ b/_posts/2017-12-31-writeup-machine_learning.md
@@ -3,7 +3,7 @@ title: "Machine Leaning - Coursera"
 layout: post
 permalink: /writeups/machine_learning/
 date: 2017-12-31 19:11:48 +0530
-tag:
+tags:
 - Machine Learning
 - Coursera
 writeup: true

--- a/_posts/2018-04-18-my-other-computer-is-your-computer.md
+++ b/_posts/2018-04-18-my-other-computer-is-your-computer.md
@@ -3,11 +3,10 @@ title: "My Other Computer is Your Computer - Malware Classification"
 layout: post
 date: 2018-05-06 00:00
 image: /assets/images/malware/malware-wide.png
-tag:
+tags:
 - Security
-- Malware
+- Malware Analysis
 - Machine Learning
-- Project
 projects: true
 description: "Classifying malware into 9 families using ML on assembly code and byte patterns"
 ---

--- a/_posts/2018-06-06-hackinout.md
+++ b/_posts/2018-06-06-hackinout.md
@@ -2,10 +2,10 @@
 title: "HackInOut 4.0 Winners - My First Blockchain Project"
 layout: post
 date: 2018-06-06 8:15
-tag:
+tags:
 - Blockchain
 - Hackathon
-- Development
+- SpamSlam
 blog: true
 redirect_to: https://devfolio.co/blog/spamslam-a-blockchain-solution-to-less-spam/
 description: "Winning HackInOut's blockchain track with a radical idea to kill spam forever"

--- a/_posts/2018-06-06-spamslam.md
+++ b/_posts/2018-06-06-spamslam.md
@@ -3,9 +3,11 @@ title: "SpamSlam - A blockchain solution to less spam"
 layout: post
 date: 2018-06-06 8:20
 image: /assets/images/SpamSlam-wide.png
-tag:
+tags:
 - Blockchain
 - Hackathon
+- SpamSlam
+- Email Security
 projects: true
 star: true
 description: "What if sending email cost a digital stamp? Our blockchain hack won first place at HackInOut"

--- a/keybase.txt
+++ b/keybase.txt
@@ -73,3 +73,79 @@ appending to this document.
 View my publicly-auditable identity here: https://keybase.io/atrehan
 
 ==================================================================
+
+==================================================================
+https://keybase.io/atrehan
+--------------------------------------------------------------------
+
+I hereby claim:
+
+  * I am an admin of https://codemaxx.github.io
+  * I am atrehan (https://keybase.io/atrehan) on keybase.
+  * I have a public key with fingerprint DCC8 A412 93A2 6897 32E9  5D41 D8BD 2439 99DE 1062
+
+To do so, I am signing this object:
+
+{
+  "body": {
+    "key": {
+      "eldest_kid": "01209bbbf2555f8ab4ec2f1677c7f63b35a9c993956adad42ad1d3ce687163276b050a",
+      "fingerprint": "dcc8a41293a2689732e95d41d8bd243999de1062",
+      "host": "keybase.io",
+      "key_id": "d8bd243999de1062",
+      "kid": "01014dc3674faed9f48a909de6b5f9f5ee4182cc2c2fd184f7ecbad8676ab6ae43f10a",
+      "uid": "a6a893d6882ac86ec9efd4db62f23e19",
+      "username": "atrehan"
+    },
+    "service": {
+      "hostname": "codemaxx.github.io",
+      "protocol": "https:"
+    },
+    "type": "web_service_binding",
+    "version": 1
+  },
+  "ctime": 1783742105,
+  "expire_in": 157680000,
+  "prev": "92a271599f6fc93ba026f8b09959280df641363724a278ecc1d4a876502cba11",
+  "seqno": 17,
+  "tag": "signature"
+}
+
+which yields the signature:
+
+-----BEGIN PGP MESSAGE-----
+Version: Keybase OpenPGP v2.1.17
+Comment: https://keybase.io/crypto
+
+yMN3AnicbVJ/TFZVGAYERSJgmd9yRsDV6RbE7s9z72Es1K30i8YyBEzkg3PvOZfv
+gnwfft8HgkhBqDBHTDBJJiiKNElCMjQFiR+JAtqQlSThIFumJhv5OwSxe0n/6/xz
+dt7zPM/7PO/ecy/PcfNxv9q+FFaNBsjuF7tqstzS1n5flUfJdpxLReRR6WT2Ipsw
+cbqS0zVMRVA0w9JQlmWVFQRBlZDME4VVGSCKiqgCTuYEBBUIOSgAhBHmWYQZzCkE
+SCIDOFYEMi3QiAqjVM2WShyZDs3m0mWxokiIZ1jIIRZIUORYAgXMM1iSMctzEEJM
+GBqwOtFqdxoM3ZyMnCRcs+s1/ZE8a+9/8C980wyPFQ6IvIoIhiovIUjrKCALKlQF
+QnhGYhWF1dNgRuJVkSgywhIQAZIBIjynMrO+s2blEEAS5DCQJBYpEiAKJCrmsQxY
+leUIAw2gkzhsKIMYaJeDWJGNyg+j9GK2phBjrkaQ5wDFjkkGyskJT9Vc1iz5v1CZ
+DrvLrtg36f9WlyvTGWHwXbmZBmELkZOfSyXLmg3rw9QZ2cTh1Ow2KoLRkYpLM7QZ
+UeJEnmVoIYwiOZmagyRrBkIQgUTrx+hDsnVJyCJWZAQIVaAqkJMRzQJVkmkIBchK
+NFYBz3CAE1lex0lEURjMI0kEAs3qk2IYygi32WY3Wuo+Uaqu6dRSbciV5SBUfnfX
+Rk83dx+3uV4expa5+cwPeLF7I63+z1wpb9eaHwRR6z/3tDvqnLFR0qOwwjH3mDui
+sFVc+ZZi/uWzTktHjGlZ20Bx77zmfyylD1v/MnmBzJRTX7f77asNGqmotORXfSjQ
+u5ZbCmISPb5aPdAxjMwblr9edGxsVev1ijP1sdHVD99pjLYlNHfF+cELTd8eB6aG
+VGcQm18gvOdR8ubW+JbuhXHdX1hq4/b7OkLvvoZn8ubbJhp8s/+w2cyrp3qCn8Ts
+fRRYvvLT41cKKhdUPAkKmYy6/OW6VLNgun6iZ33SvcZzVxM+8OjZsSxl54NXFodO
+tjUU4hPtA/5NXpejD3iPtb3/68CqWGtJLHNjB9uaUem/4GJz1a1rZ+dOl0YGt5qi
+Nkz7v9p2wzsxOfS+0jB1p96vvIIeGmyy9oVXp1fN8dqZ/vv5C9UH9nj2R18LOLm3
+LK1hTc1McbCpM+Vw+UuVw/VH/3x3XkS0dnvJwbqfBO5mwuja/nVenPk2d+V0RmHj
+iokju/sT2ory+kOO+G4rDOB+TDq1Z3v/mqmy4N8iAx8n5p5+I6b66f0fxjuOHrIs
+7Sw6PLM/5Jjv9oKK7s2TC30CR4O94+uTZno7zh8cLPZrKLd+3BvZl3vo75zyfZda
+Wr679+znu6HjA08XDcanDTV3+KncyPSSIcVz+FbZxl0TxR8tLmFMZ072lY5/smib
+WPV4fOhS4IqzKdM9E1tqRm7WgW/+BbCuyqI=
+=nHRC
+-----END PGP MESSAGE-----
+
+And finally, I am proving ownership of this host by posting or
+appending to this document.
+
+View my publicly-auditable identity here: https://keybase.io/atrehan
+
+==================================================================


### PR DESCRIPTION
## Summary

- Standardizes tag metadata and taxonomy across all 56 published posts.
- Consolidates inconsistent/vague labels while keeping each post at 2-4 focused tags.
- Replaces the single generic Bandit label with per-level technique tags so the 20 Bandit posts become browsable by skill (Shell, SSH, File Analysis, Text Processing, Encoding, Networking, Privilege Escalation).
- Includes the updated Keybase host ownership proof.

## Before and after

### Tag index taxonomy

| Before (live site) | After (production local build) |
| --- | --- |
| ![Tag index before](https://github.com/CodeMaxx/CodeMaxx.github.io/releases/download/pr-assets/tag-taxonomy-before-index.png) | ![Tag index after](https://github.com/CodeMaxx/CodeMaxx.github.io/releases/download/pr-assets/tag-taxonomy-after-index.png) |

### Bandit technique tags

| Before (live site) | After (production local build) |
| --- | --- |
| ![Bandit tags before](https://github.com/CodeMaxx/CodeMaxx.github.io/releases/download/pr-assets/tag-taxonomy-before-post.png) | ![Bandit tags after](https://github.com/CodeMaxx/CodeMaxx.github.io/releases/download/pr-assets/tag-taxonomy-after-post.png) |

### BackdoorCTF series and topic tags

| Before (live site) | After (production local build) |
| --- | --- |
| ![BackdoorCTF tags before](https://github.com/CodeMaxx/CodeMaxx.github.io/releases/download/pr-assets/tag-taxonomy-before-backdoor.png) | ![BackdoorCTF tags after](https://github.com/CodeMaxx/CodeMaxx.github.io/releases/download/pr-assets/tag-taxonomy-after-backdoor.png) |

## Notes on scope

- The generic `BackdoorCTF` tag already groups the series, so no per-year tags were added.
- Keeps the existing `C` and `Cpp` archives separate to avoid Jekyll slugifying `C++` onto `/tags/c/`.
- No tag redirects were added: tag archives are auto-generated navigation pages introduced during the recent Chirpy migration, with no meaningful inbound links to preserve.

## Validation

- Production Jekyll build completes successfully.
- Verified generated tag pages, per-post tag counts (all 2-4), and representative posts.
