### PR TITLE
Remove migration-added theme-override comments

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,6 +1,4 @@
 <!-- The Footer -->
-<!-- Local override of the theme footer: drops the "Powered by" theme
-     credit line; keeps the copyright. -->
 
 <footer
   aria-label="Site Info"

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,13 +1,3 @@
-<!--
-  Local override of the theme's head.
-  Changes vs. the base theme:
-    1. Loads the site stylesheet from a neutral path (/assets/css/style.css)
-       instead of the theme-name-derived path.
-    2. Drops the PWA service-worker registration and instead unregisters any
-       previously-installed worker (and clears its caches) so visitors always
-       get the freshly deployed site and never see an "update available"
-       prompt.
--->
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
   <meta name="theme-color" media="(prefers-color-scheme: light)" content="#f7f7f7">
@@ -124,8 +114,6 @@
 
   {% include js-selector.html lang=lang %}
 
-  <!-- Retire any previously-registered PWA service worker and its caches, so
-       returning visitors always load the freshly deployed site with no prompt. -->
   <script>
     if ('serviceWorker' in navigator) {
       navigator.serviceWorker.getRegistrations().then(function (regs) {

--- a/_includes/related-posts.html
+++ b/_includes/related-posts.html
@@ -1,12 +1,3 @@
-<!--
-  Local override of the theme's related-posts ("Further Reading") include.
-  Behaves exactly like the theme default (scores the other posts by shared
-  tags/categories and shows the top 3), but for posts with `redirect_to` it
-  links straight to the external target in a new tab and appends the same
-  external-link badge used on the listing cards, so external entries read
-  consistently everywhere they appear.
--->
-
 <!-- Recommend the other 3 posts according to the tags and categories of the current post. -->
 
 <!-- The total size of related posts -->

--- a/_includes/search-loader.html
+++ b/_includes/search-loader.html
@@ -1,8 +1,6 @@
 <!--
-  Local override of the theme's Simple-Jekyll-Search loader.
-  Shows each post's `description` in the results (cleaner than a raw body
-  excerpt) while the body `content` remains in the search index for
-  full-text matching. See: <https://github.com/christian-fei/Simple-Jekyll-Search>
+  Jekyll Simple Search loader
+  See: <https://github.com/christian-fei/Simple-Jekyll-Search>
 -->
 
 {% capture result_elem %}

--- a/_includes/topbar.html
+++ b/_includes/topbar.html
@@ -1,12 +1,4 @@
 <!-- The Top Navigation Bar -->
-<!--
-  Local override: replaces the theme's left sidebar with a full-width top nav.
-  Left = brand (name); right = page links + search + dark/light toggle.
-  The mode-toggle markup is moved here from the sidebar (the theme JS binds to
-  `#mode-toggle + .dropdown-menu`). Search elements keep their original IDs so
-  the theme's search JS keeps working. `#sidebar-trigger` / `#topbar-title`
-  are retained (hidden on desktop) because the theme JS references them.
--->
 
 <header id="topbar-wrapper" class="flex-shrink-0" aria-label="Top Navigation">
   <div id="topbar" class="d-flex align-items-center h-100">

--- a/_layouts/archives.html
+++ b/_layouts/archives.html
@@ -2,14 +2,6 @@
 layout: page
 # The Archives of posts.
 ---
-<!--
-  Local override of the theme's archives layout. The theme iterates site.posts in
-  date+time order, so a same-day series (e.g. the OverTheWire Bandit levels,
-  all 2016-05-31) lists in commit-time order rather than level order. We sort
-  by a composite "YYYYMMDD#url" key (day, then zero-padded slug) and reverse
-  it: newest day first, and within a day level19 → level00. Year grouping is
-  unaffected because the primary key is still the date.
--->
 
 {% include lang.html %}
 

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -3,15 +3,6 @@ layout: default
 refactor: true
 ---
 
-{% comment %}
-  Local override of the theme's `home` layout. Behaves exactly like the theme
-  default for the paginated front page, but also powers the Blog / Write-ups /
-  Projects listing tabs: a tab sets `layout: home` + a `list_source` and this
-  layout renders the matching posts with the same card markup (no paginator).
-  Keeping `layout: home` means `page.layout == 'home'`, so the theme's
-  image refactor still gives cards the `preview-img` treatment.
-{% endcomment %}
-
 {% include lang.html %}
 
 {% assign posts = '' | split: '' %}

--- a/_layouts/tag.html
+++ b/_layouts/tag.html
@@ -4,17 +4,6 @@ panel_includes:
   - all-tags
 # The layout for Tag page
 ---
-<!--
-  Local override of the theme's tag layout. jekyll-archives orders a tag's posts
-  by date+time only, so a same-day series (e.g. the OverTheWire Bandit levels,
-  all committed 2016-05-31) comes out in commit-time order, not level order.
-
-  We sort with a single composite key "YYYYMMDD#url" (day-granularity date,
-  then URL) and reverse it: newest day first, and within a day the zero-padded
-  slugs (level00…level19) read level19 → level00 down the page. A single sort
-  avoids relying on sort stability (Jekyll's `sort` is not stable). The
-  "@@@index" suffix keeps keys unique and maps back to the original post.
--->
 
 {% include lang.html %}
 

--- a/assets/js/data/search.json
+++ b/assets/js/data/search.json
@@ -3,14 +3,6 @@ layout: compress
 swcache: true
 ---
 
-{% comment %}
-  Local override of the theme's search index.
-  Adds a `description` field (shown in results) while keeping `content`
-  (the post body) in the index so full-text matching still works.
-  `description` falls back to the body summary, then the title, so it is
-  never empty (which would otherwise render a literal placeholder).
-{% endcomment %}
-
 [
   {% for post in site.posts %}
   {% if post.redirect_to %}


### PR DESCRIPTION
## What

Strips the verbose comments that the Chirpy migration PRs (#65–#68) added to the theme files I override, so the overrides read as plain code.

**Removed** (migration-added prose):
- The `Local override of the theme…` / `Changes vs. the base theme` banners on `head.html`, `footer.html`, `topbar.html`, and `related-posts.html`.
- The PWA "update available" / service-worker explainer comment in `head.html`.
- The sorting/override explanations in `archives.html`, `tag.html`, `home.html`, and the search-index comment in `search.json`.

**Kept / restored** (original Chirpy comments):
- Original section labels: `<!-- The Footer -->`, `<!-- Recommend the other 3 posts… -->`, `<!-- The Top Navigation Bar -->`.
- Restored the theme's original `Jekyll Simple Search loader` comment in `search-loader.html`, which the added comment had overwritten.

## Why

These were AI-generated meta-comments explaining the customizations rather than documenting anything non-obvious. Removing them keeps the override files clean. Verified each removal against the `jekyll-theme-chirpy` 7.6.0 gem so no original theme comment was lost.

## Scope

Comment-only: **2 insertions, 71 deletions across 9 files.** No code or behavior changes. Production build is clean and `search.json` still emits valid JSON.

## Screenshots

None — comment-only change with zero rendered/visual difference.
