### PR TITLE
Fix broken internal links and restore external link checking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,21 +26,12 @@ jobs:
           ruby-version: "3.4"
           bundler-cache: true
 
-      - name: Build site
-        run: bundle exec jekyll b
+      - name: Build site and check links
+        run: bundle exec rake test
         env:
           JEKYLL_ENV: "production"
-
-      - name: Check links (html-proofer)
-        run: |
-          bundle exec htmlproofer _site \
-            --disable-external \
-            --no-enforce-https \
-            --allow-hash-href \
-            --ignore-files "/cs741/"
-        # /cs741/ holds self-contained static course-project test artifacts
-        # (their own HTML with broken relative links and /wiki/* references);
-        # not part of the blog, so excluded from link checking.
-        # --disable-external skips network checks; --no-enforce-https is kept
-        # because imported CTF write-ups link to legacy http-only challenge
-        # resources (e.g. hack.bckdr.in).
+        # `rake test` builds the site and runs html-proofer with external link
+        # checking enabled, configured via .htmlproofer.yaml: a curated
+        # ignore list of dead / bot-blocked external domains plus the /cs741/
+        # static course-project test artifacts. A realistic User-Agent and
+        # generous timeouts (set in the Rakefile) keep external checks stable.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,12 +37,10 @@ jobs:
             --disable-external \
             --no-enforce-https \
             --allow-hash-href \
-            --ignore-files "/cs741/" \
-            --ignore-urls "/^\/wiki\//,/\/blog$/,/\/projects$/,/\/writeups$/,/crate\.png$/"
-        # Ignores are pre-existing content debt (not theme-migration issues),
-        # carried over from the old .htmlproofer.yaml plus links to sections
-        # deferred during the Chirpy migration. Tracked in beads for a content
-        # pass: /wiki/* relative Wikipedia links, the /blog//projects//writeups
-        # post-body links, the /cs741/ static test artifacts, and crate.png.
-        # --enforce-https is off because the imported CTF write-ups link to
-        # legacy http-only challenge resources (e.g. hack.bckdr.in).
+            --ignore-files "/cs741/"
+        # /cs741/ holds self-contained static course-project test artifacts
+        # (their own HTML with broken relative links and /wiki/* references);
+        # not part of the blog, so excluded from link checking.
+        # --disable-external skips network checks; --no-enforce-https is kept
+        # because imported CTF write-ups link to legacy http-only challenge
+        # resources (e.g. hack.bckdr.in).

--- a/.htmlproofer.yaml
+++ b/.htmlproofer.yaml
@@ -1,0 +1,32 @@
+# html-proofer configuration
+# https://github.com/gjtorikian/html-proofer#configuration
+
+# URLs to ignore (regex patterns)
+ignore_urls:
+  - /linkedin\.com/                         # Returns 999 (JS-based bot detection)
+  - /instagram\.com/                        # Returns 429 (aggressive rate limiting)
+  - /facebook\.com/                         # Returns 400 (JS-based bot detection)
+  - /blackhat\.com/                         # Returns 403 (Cloudflare JS challenge)
+  - /iitb\.ac\.in/                          # Flaky connection (works in browsers)
+  - /devfolio\.co/                          # Blocks GitHub Actions IPs
+  - /morsecode\.scphillips\.com/            # Blocks GitHub Actions IPs
+  - /hack\.bckdr\.in/                       # Backdoor CTF server sunset by SDSLabs
+  - /github\.com\/CodeMaxx\/Binary-Exploitation.*#/  # GitHub JS-rendered anchors (false positive)
+  - /ctf\.infosecinstitute\.com/            # CTF server no longer available
+  - /westwind\.com/                         # Site no longer active
+  - /citeseerx\.ist\.psu\.edu/              # PDF downloads broken (502)
+  # Chirpy theme head/footer links (introduced by the theme, not post content):
+  - /twitter\.com/                          # X/Twitter returns 404 to bots (JS-based)
+  - /\bx\.com/                              # X/Twitter returns 404 to bots (JS-based)
+  - /fonts\.googleapis\.com/                # Preconnect hint; bare host 404s but font CSS is valid
+  - /fonts\.gstatic\.com/                   # Preconnect hint; bare host 404s but fonts are valid
+
+# Files/directories to ignore (paths relative to _site)
+ignore_files:
+  - /cs741/
+
+# Allow anchor tags without href attribute
+allow_missing_href: true
+
+# Allow hash href (href="#")
+allow_hash_href: true

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,55 @@
+require 'html-proofer'
+require 'yaml'
+
+# rake test
+desc "build and test website"
+
+task :test do
+  sh "bundle exec jekyll build"
+  
+  # Load config from YAML file
+  config = YAML.load_file('.htmlproofer.yaml')
+  
+  options = {
+    allow_hash_href: config['allow_hash_href'] || true,
+    allow_missing_href: config['allow_missing_href'] || false,
+    typhoeus: {
+      headers: {
+        "User-Agent" => "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+        "Accept" => "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
+        "Accept-Language" => "en-US,en;q=0.5"
+      },
+      connecttimeout: 30,
+      timeout: 60,
+      ssl_verifypeer: true,
+      followlocation: true
+    },
+    hydra: {
+      max_concurrency: 10
+    }
+  }
+  
+  # Convert ignore_urls strings to regexes
+  if config['ignore_urls']
+    options[:ignore_urls] = config['ignore_urls'].map do |pattern|
+      if pattern.start_with?('/') && pattern.end_with?('/')
+        Regexp.new(pattern[1..-2])
+      else
+        pattern
+      end
+    end
+  end
+  
+  # Convert ignore_files strings to regexes
+  if config['ignore_files']
+    options[:ignore_files] = config['ignore_files'].map do |pattern|
+      if pattern.start_with?('/') && pattern.end_with?('/')
+        Regexp.new(pattern[1..-2])
+      else
+        pattern
+      end
+    end
+  end
+  
+  HTMLProofer.check_directory('./_site', options).run
+end

--- a/_posts/2016-06-07-importance-of-quotes-in-terminal.md
+++ b/_posts/2016-06-07-importance-of-quotes-in-terminal.md
@@ -64,4 +64,4 @@ test ~/*.txt {code,maxx} $(echo foo) $((2+2)) $USER `echo bar` \$100
 
 We see that using single quotes prevents all expansions. ALL special characters lose thier meaning! This is why it is recommended to use single quotes while writing aliases so that we can put the exact input in it and we don't have to worry about it being modified while substitution.
 
-**Hope this helped :) In case you have any doubts comment below. If you are an Infosec person, don't forget to checkout my [Write-ups](../../writeups)**
+**Hope this helped :) In case you have any doubts comment below. If you are an Infosec person, don't forget to checkout my [Write-ups](/writeups/)**

--- a/_posts/2016-06-15-different-kinds-of-executables.md
+++ b/_posts/2016-06-15-different-kinds-of-executables.md
@@ -86,6 +86,6 @@ This the ELF interpreter. It is responsible for dynamic linking.
 
 **Cheers!**
 
-**If you are an Infosec person, don't forget to checkout my [CTF Write-ups](../../writeups)**
+**If you are an Infosec person, don't forget to checkout my [CTF Write-ups](/writeups/)**
 
-[See other Blog posts](../blog)
+[See other Blog posts](/blog/)

--- a/_posts/2016-07-04-owasp-zsc.md
+++ b/_posts/2016-07-04-owasp-zsc.md
@@ -40,4 +40,4 @@ Its a great learning experience for me. This is the first time I have been writi
 For a list of my contributions to this project follow [this link](https://github.com/OWASP/ZSC/pulls?utf8=%E2%9C%93&q=is%3Apr%20author%3ACodeMaxx). For any queries about the project feel free to comment below. :)
 
 <br>
-Do check out other [projects](../../projects), [my blog](../../blog) or [my write-ups](../../writeups) for various CTFs.
+Do check out other [projects](/projects/), [my blog](/blog/) or [my write-ups](/writeups/) for various CTFs.

--- a/_posts/2016-11-03-did-i-execute.md
+++ b/_posts/2016-11-03-did-i-execute.md
@@ -80,4 +80,4 @@ $ false && echo success || echo fail
 fail
 ```
 
-**Hope this helped :) In case you have any doubts comment below. If you are an Infosec person, don't forget to checkout my [Write-ups](../../writeups)**
+**Hope this helped :) In case you have any doubts comment below. If you are an Infosec person, don't forget to checkout my [Write-ups](/writeups/)**

--- a/_posts/2017-08-25-csec-binary-exploitation-1.md
+++ b/_posts/2017-08-25-csec-binary-exploitation-1.md
@@ -28,6 +28,6 @@ Constructive criticism is much appreciated.
 
 **Cheers!**
 
-**If you are an Infosec person, don't forget to checkout my [CTF Write-ups](../../writeups)**
+**If you are an Infosec person, don't forget to checkout my [CTF Write-ups](/writeups/)**
 
-[See other Blog posts](../blog)
+[See other Blog posts](/blog/)

--- a/_posts/2017-10-18-Ubisoft-GameJam-Winners.md
+++ b/_posts/2017-10-18-Ubisoft-GameJam-Winners.md
@@ -41,6 +41,6 @@ Thank you for reading!
 
 **Cheers!**
 
-**If you are an Infosec person, don't forget to checkout my [CTF Write-ups](../../writeups)**
+**If you are an Infosec person, don't forget to checkout my [CTF Write-ups](/writeups/)**
 
-[See other Blog posts](../blog)
+[See other Blog posts](/blog/)

--- a/_posts/2017-11-08-csec-binary-exploitation-2.md
+++ b/_posts/2017-11-08-csec-binary-exploitation-2.md
@@ -27,6 +27,6 @@ Constructive criticism is much appreciated.
 
 **Cheers!**
 
-**If you are an Infosec person, don't forget to checkout my [CTF Write-ups](../../writeups)**
+**If you are an Infosec person, don't forget to checkout my [CTF Write-ups](/writeups/)**
 
-[See other Blog posts](../blog)
+[See other Blog posts](/blog/)

--- a/_posts/2017-12-13-project-ditch.md
+++ b/_posts/2017-12-13-project-ditch.md
@@ -62,4 +62,4 @@ The report is in another post [here](../indexing-schemes/).
 The [code for this project](https://github.com/CodeMaxx/postgres-with-stepped-merge-index) has been open-sourced on Github.
 
 <br>
-Do check out other [projects](../../projects), [my blog](../../blog) or [my write-ups](../../writeups) for various CTFs.
+Do check out other [projects](/projects/), [my blog](/blog/) or [my write-ups](/writeups/) for various CTFs.

--- a/_posts/2017-12-23-right-way-to-use-sublime-text.md
+++ b/_posts/2017-12-23-right-way-to-use-sublime-text.md
@@ -46,6 +46,6 @@ Again, do try all this out by yourself!
 
 **Cheers!**
 
-**If you are an Infosec person, don't forget to checkout my [CTF Write-ups](../../writeups)**
+**If you are an Infosec person, don't forget to checkout my [CTF Write-ups](/writeups/)**
 
-[See other Blog posts](../blog)
+[See other Blog posts](/blog/)


### PR DESCRIPTION
## What

Two related link-integrity fixes for the CI `html-proofer` step:

1. **Fix migration-era broken internal links.**
2. **Restore external link checking** that the Chirpy migration had silently disabled.

## 1. Internal links

Several older posts (from the pre-Chirpy Indigo layout) linked to site sections with **relative** paths that assumed the old structure (`../../writeups`, `../../projects`, `../../blog`, `../blog`). Under Chirpy's flat permalinks these resolve above the site root, so html-proofer flagged them — and CI papered over them with an `--ignore-urls` list.

Repointed all of them at the canonical Chirpy tab permalinks (which now exist as nav tabs):

| Old link | New link |
| --- | --- |
| `../../writeups`, `../writeups` | `/writeups/` |
| `../../projects` | `/projects/` |
| `../../blog`, `../blog` | `/blog/` |

Verified by clicking every changed link in a real browser (Playwright): each lands on the correct, populated tab — `/projects/` (8 cards), `/blog/` (12 cards), `/writeups/` (36 cards).

## 2. Restore external link checking

The Chirpy migration (PR #65) had **disabled external link checking** (`htmlproofer --disable-external --no-enforce-https`) and deleted the old `.htmlproofer.yaml` + `Rakefile`. That meant dead external links (e.g. sunset CTF servers) stopped being caught. This restores the pre-migration behaviour:

- **`Rakefile`** — restored the `test` task: builds the site, then runs HTMLProofer via the Ruby API with a realistic browser User-Agent, generous timeouts, and `max_concurrency: 10` (all of which reduce external-check flakiness).
- **`.htmlproofer.yaml`** — restored the curated ignore list of genuinely dead / bot-blocked / rate-limited external domains (linkedin, instagram, facebook, blackhat, iitb, devfolio, morsecode, hack.bckdr.in, infosecinstitute, westwind, citeseerx). Added entries for Chirpy-theme head/footer links that 404 to bots or are preconnect hints: `twitter.com`, `x.com`, `fonts.googleapis.com`, `fonts.gstatic.com`.
- **`ci.yml`** — the check step now runs `bundle exec rake test` (build + external + internal link checking) instead of the inline `htmlproofer --disable-external`. The old `--ignore-urls` list of *internal* paths is gone: `/blog`, `/projects`, `/writeups` are fixed above, and `/wiki/*` + `crate.png` only ever occurred inside `assets/cs741/`, which stays excluded via `ignore_files: /cs741/`.

## Verification

- **Playwright** click-through of every changed internal link → correct pages.
- **html-proofer run locally** (build + `rake test`): **312 external + 348 internal links, 0 failures.**
- Two independent adversarial code reviews (internal-link fixes; external-checking restoration) — no CI-breaking issues found.

## Note on external-check flakiness

External link checking runs on every PR/push and has no retry, so a transient rate-limit/timeout from a third-party host can occasionally redden CI (this is the same tradeoff the Indigo site lived with — the ignore list was tuned over time from real CI failures). If a domain blocks GitHub Actions' IPs, it just needs adding to `.htmlproofer.yaml`'s `ignore_urls`.

## Screenshots

No visual/layout changes — only link *targets* and CI configuration change.
