### PR TITLE
Align social handles to theakashtrehan (+ add YouTube)

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -26,7 +26,7 @@ github:
   username: CodeMaxx # change to your GitHub username
 
 twitter:
-  username: cod3maxx # change to your Twitter username
+  username: theakashtrehan # change to your Twitter username
 
 social:
   # Change to your full name.
@@ -37,10 +37,11 @@ social:
   links:
     # The first element serves as the copyright owner's link
     - https://github.com/CodeMaxx
-    - https://twitter.com/cod3maxx
+    - https://twitter.com/theakashtrehan
     - https://www.linkedin.com/in/akash-trehan
-    - https://www.facebook.com/AkashTrehan21
-    - https://www.instagram.com/akash.trehan
+    - https://www.facebook.com/theakashtrehan
+    - https://www.instagram.com/theakashtrehan
+    - https://www.youtube.com/@theakashtrehan
 
 # Site Verification Settings
 webmaster_verifications:

--- a/_data/contact.yml
+++ b/_data/contact.yml
@@ -12,11 +12,15 @@
 
 - type: facebook
   icon: "fab fa-facebook"
-  url: "https://www.facebook.com/AkashTrehan21"
+  url: "https://www.facebook.com/theakashtrehan"
 
 - type: instagram
   icon: "fab fa-instagram"
-  url: "https://www.instagram.com/akash.trehan"
+  url: "https://www.instagram.com/theakashtrehan"
+
+- type: youtube
+  icon: "fab fa-youtube"
+  url: "https://www.youtube.com/@theakashtrehan"
 
 - type: email
   icon: "fas fa-envelope"


### PR DESCRIPTION
## Summary

Consolidates my public social identity under a single handle — **`theakashtrehan`** — and updates the site's outbound social links and `sameAs` metadata to point at the current profiles. Also adds a **YouTube** icon/link.

| Platform | Before | After |
|---|---|---|
| X | `cod3maxx` | **`theakashtrehan`** |
| Facebook | `AkashTrehan21` | **`theakashtrehan`** |
| Instagram | `akash.trehan` | **`theakashtrehan`** |
| YouTube | _(not linked)_ | **`@theakashtrehan`** (new icon) |
| GitHub | `CodeMaxx` | `CodeMaxx` _(unchanged — established dev identity)_ |
| LinkedIn | `akash-trehan` | `akash-trehan` _(unchanged — real-name URL, kept stable)_ |

## Changes
- **`_config.yml`** — `twitter.username`, and the `social.links` list (X, Facebook, Instagram updated; YouTube added).
- **`_data/contact.yml`** — Facebook & Instagram `url`s updated; new `youtube` entry added to the contact/social icon row.

## Before / After (hero social row)
The only *visual* change is the new **YouTube** icon (inserted between Instagram and email); every other icon is unchanged — only its link target was updated.

**Before** (live production, akashtrehan.com):

![Before social row](https://raw.githubusercontent.com/CodeMaxx/CodeMaxx.github.io/pr-assets/before-socials.png)

**After** (local production build):

![After social row](https://raw.githubusercontent.com/CodeMaxx/CodeMaxx.github.io/pr-assets/after-socials.png)

## Verification
- ✅ Production build succeeds: `JEKYLL_ENV=production bundle exec jekyll build`
- ✅ Confirmed `youtube.com/@theakashtrehan` present in built `_site` output
- ✅ Rendered locally — new YouTube icon appears in the hero + footer social row (screenshots above)
