### PR TITLE
Fix page titles and remove phantom paginated homepage duplicates

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -130,8 +130,6 @@ pwa:
     enabled: false # The option for PWA offline cache
     deny_paths:
 
-paginate: 10
-
 # The base URL of your site
 baseurl: ""
 

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -54,11 +54,12 @@
   {% endif %}
 
   <title>
-    {%- unless page.layout == 'home' -%}
+    {%- unless page.layout == 'landing' -%}
       {%- capture title -%}
         {%- if page.collection == 'tabs' -%}
           {%- assign tab_key = page.title | downcase -%}
-          {{- site.data.locales[include.lang].tabs[tab_key] -}}
+          {%- assign tab_i18n = site.data.locales[include.lang].tabs[tab_key] -%}
+          {{- tab_i18n | default: page.title -}}
         {%- else -%}
           {{- page.title -}}
         {%- endif -%}


### PR DESCRIPTION
## Summary

Two closely-related `<head>` / SEO fixes discovered together:

1. **Browser tab titles** (`<title>`) were wrong on several pages.
2. The homepage was being **cloned into phantom `/page2`–`/page6` duplicates** by a leftover pagination setting.

## 1. Tab titles

The title template in `_includes/head.html` suppressed the `<page> | ` prefix for `page.layout == 'home'`. But:

- The real homepage uses the custom **`landing`** layout, so it fell into the prefix branch with an empty `page.title` → `" | Akash Trehan"` (stray leading pipe).
- Blog / Projects / Write-ups reuse Chirpy's **`home`** layout as a shared listing layout, so they inherited the "no prefix" rule → bare `Akash Trehan`, colliding with the homepage and each other.

**Fix:** suppress the prefix **only** for the `landing` layout, and fall back to `page.title` when a tab has no localized name (the custom Blog/Projects/Write-ups tabs aren't in the theme's locale data).

### Before / After

A `<title>` change is browser-chrome (the tab), so it has no page-body visual. The faithful before/after is the rendered title text — **before** from the live site, **after** from a local production build:

| Page | Before (live) | After |
|------|---------------|-------|
| **Home** `/` | `​ \| Akash Trehan` ⚠️ | `Akash Trehan` |
| **Blog** `/blog/` | `Akash Trehan` ⚠️ | `Blog \| Akash Trehan` |
| **Projects** `/projects/` | `Akash Trehan` ⚠️ | `Projects \| Akash Trehan` |
| **Write-ups** `/writeups/` | `Akash Trehan` ⚠️ | `Write-ups \| Akash Trehan` |
| About `/about/` | `About \| Akash Trehan` | unchanged |
| Tags `/tags/` | `Tags \| Akash Trehan` | unchanged |
| Archives `/archives/` | `Archives \| Akash Trehan` | unchanged |
| Post | `Checking out Stuff \| Akash Trehan` | unchanged |

Every section page now carries its descriptive prefix; the homepage is the sole bare-brand exception (standard convention, best for SEO).

## 2. Phantom paginated homepage duplicates

`_config.yml` still had `paginate: 10` from the old theme setup. jekyll-paginate used it to paginate the site index, generating `/page2` … `/page6` — but the homepage now uses the `landing` layout, which renders a fixed "Recent posts" list and **never touches the paginator**. So those six pages were **exact duplicates of the homepage** (same `<h1>`, same content) — duplicate content that hurts SEO.

Nothing depends on the setting: the section listings (Blog/Projects/Write-ups) render all their posts via the `list_source` branch with no paginator, and no page uses the `home` layout without `list_source`.

**Fix:** removed `paginate: 10`. `/page2`–`/page6` are no longer generated.

## Testing

- Production Jekyll build (`JEKYLL_ENV=production bundle exec jekyll build`) passes.
- Verified the rendered `<title>` of every page above in `_site/`.
- Confirmed `/page2`–`/page6` are gone, and that Blog (13), Projects (8), and Write-ups (36) still list all their posts.
