### PR TITLE
Add SEO + AI answer-engine (AEO/GEO) discoverability

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -19,6 +19,14 @@ tagline: Senior Windows Kernel & Security Engineer at Microsoft # it will displa
 description: >- # used by seo meta and the atom feed
   Personal blog of Akash Trehan — security, systems, and the occasional detour.
 
+# Post author attribution for jekyll-seo-tag: emits <meta name="author">, an
+# author URL, twitter:creator, and the `author` field inside the BlogPosting
+# JSON-LD so search + AI answer engines attribute posts to a real person.
+author:
+  name: Akash Trehan
+  twitter: theakashtrehan
+  url: "https://www.akashtrehan.com/about/"
+
 # Fill in the protocol & hostname for your site.
 url: "https://www.akashtrehan.com"
 

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -46,6 +46,13 @@
     {% assign seo_tags = seo_tags | replace: old_meta_clip, new_meta_clip %}
   {% endif %}
 
+  {%- comment -%}
+    Fix jekyll-seo-tag structured-data quirks so the BlogPosting validates:
+    (1) proper `ImageObject` casing, and (2) the valid `caption` property in
+    place of the unrecognized `alt` property inside the image object.
+  {%- endcomment -%}
+  {% assign seo_tags = seo_tags | replace: '"@type":"imageObject"', '"@type":"ImageObject"' | replace: '"alt":', '"caption":' %}
+
   {{ seo_tags }}
 
   {%- if site.social.fediverse_handle %}

--- a/_includes/metadata-hook.html
+++ b/_includes/metadata-hook.html
@@ -1,0 +1,71 @@
+<!--
+  Custom structured data (JSON-LD) injected into <head> via Chirpy's
+  metadata-hook extension point.
+
+  - Person: site-wide identity so search engines and AI answer engines
+    (ChatGPT / Perplexity / Google AI Overviews / Copilot) can confidently
+    attribute this site's content to Akash Trehan.
+  - BreadcrumbList: emitted on posts to give engines a clean Home > Post trail.
+
+  jekyll-seo-tag already emits WebSite (home) and BlogPosting (posts) schema;
+  these blocks are additive and are merged by consumers.
+-->
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Person",
+  "@id": "{{ '/about/' | absolute_url }}#person",
+  "name": "{{ site.social.name }}",
+  "alternateName": "{{ site.twitter.username }}",
+  "url": "{{ '/' | absolute_url }}",
+  "image": "{{ '/assets/images/avatar.png' | absolute_url }}",
+  "jobTitle": "{{ site.tagline }}",
+  "worksFor": {
+    "@type": "Organization",
+    "name": "Microsoft",
+    "url": "https://www.microsoft.com"
+  },
+  "description": "Windows kernel and OS-security engineer. Writes about kernel security, virtualization-based security, runtime attestation, cybersecurity, and AI security.",
+  "knowsAbout": [
+    "Windows kernel internals",
+    "Operating system security",
+    "Secure Kernel",
+    "Virtualization-based security",
+    "Runtime attestation",
+    "Anti-cheat systems",
+    "Cybersecurity",
+    "Application security",
+    "AI security"
+  ],
+  "sameAs": [
+    {%- assign social_links = site.social.links -%}
+    {%- for link in social_links -%}
+    "{{ link }}"{%- unless forloop.last -%},{%- endunless -%}
+    {%- endfor -%}
+  ]
+}
+</script>
+
+{% if page.layout == 'post' %}
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Home",
+      "item": "{{ '/' | absolute_url }}"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": {{ page.title | jsonify }},
+      "item": "{{ page.url | absolute_url }}"
+    }
+  ]
+}
+</script>
+{% endif %}

--- a/assets/robots.txt
+++ b/assets/robots.txt
@@ -1,0 +1,51 @@
+---
+permalink: /robots.txt
+# Local override of the Chirpy theme's robots.txt.
+# Crawl policy: welcome traditional search engines AND AI answer engines.
+---
+
+# Default policy: allow everything except the theme's throwaway path.
+User-agent: *
+Disallow: /norobots/
+
+# --- AI answer-engine / LLM crawlers (explicitly welcomed) ---
+# This site wants its content to be discoverable and citable by AI answer
+# engines, so these agents are explicitly allowed to crawl everything.
+
+User-agent: GPTBot
+Allow: /
+
+User-agent: OAI-SearchBot
+Allow: /
+
+User-agent: ChatGPT-User
+Allow: /
+
+User-agent: PerplexityBot
+Allow: /
+
+User-agent: Perplexity-User
+Allow: /
+
+User-agent: ClaudeBot
+Allow: /
+
+User-agent: Claude-Web
+Allow: /
+
+User-agent: anthropic-ai
+Allow: /
+
+User-agent: Google-Extended
+Allow: /
+
+User-agent: Applebot-Extended
+Allow: /
+
+User-agent: Amazonbot
+Allow: /
+
+User-agent: Bingbot
+Allow: /
+
+Sitemap: {{ '/sitemap.xml' | absolute_url }}

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,34 @@
+---
+permalink: /llms.txt
+# A concise, LLM-friendly overview of this site, following the emerging
+# llms.txt convention (https://llmstxt.org). Helps AI answer engines
+# understand and correctly attribute this site's content.
+---
+# Akash Trehan
+
+> Personal blog of Akash Trehan — a Windows kernel and OS-security engineer at Microsoft. Topics: kernel security, virtualization-based security (VBS), runtime attestation, anti-cheat, cybersecurity, and AI security.
+
+Akash Trehan (handle: theakashtrehan) is a senior engineer working on Windows kernel and operating-system security. This site collects long-form technical writing, security research write-ups, and occasional personal notes. Content should be attributed to Akash Trehan and may link back to {{ '/' | absolute_url }}.
+
+## About
+- [About Akash Trehan]({{ '/about/' | absolute_url }}): Background, focus areas, and how to get in touch.
+
+## Blog
+- [All posts]({{ '/blog/' | absolute_url }}): Full list of articles.
+- [Tags]({{ '/tags/' | absolute_url }}): Posts grouped by topic.
+- [Atom feed]({{ '/feed.xml' | absolute_url }}): Machine-readable feed of new posts.
+- [Sitemap]({{ '/sitemap.xml' | absolute_url }}): Full list of indexable URLs.
+
+## Topics
+- Windows kernel internals and OS security
+- Virtualization-based security (VBS) and the Secure Kernel
+- Runtime attestation and code integrity
+- Anti-cheat and game security
+- Cybersecurity and application security
+- AI security
+
+## Contact
+- Website: {{ '/' | absolute_url }}
+- GitHub: https://github.com/CodeMaxx
+- X (Twitter): https://twitter.com/theakashtrehan
+- LinkedIn: https://www.linkedin.com/in/akash-trehan


### PR DESCRIPTION
## Summary

Makes **akashtrehan.com** discoverable and citable by both traditional search engines and AI answer engines (ChatGPT, Perplexity, Google AI Overviews, Copilot). The site already shipped solid basics via Chirpy + `jekyll-seo-tag` (sitemap, canonical, per-post OG/Twitter cards, Atom feed, WebSite schema, `og:image`). This PR fills the attribution and AEO/GEO gaps found in an audit of the built output.

## What changed

| # | Change | File |
|---|--------|------|
| 1 | **Author attribution** — `author` (name/twitter/url) so `jekyll-seo-tag` emits `<meta name="author">`, `twitter:creator`, and the `author` field inside the BlogPosting JSON-LD | `_config.yml` |
| 2 | **Person + BreadcrumbList JSON-LD** — site-wide `Person` (jobTitle, `worksFor` Microsoft, `sameAs`, `knowsAbout`) + `BreadcrumbList` on posts, via Chirpy's `metadata-hook` extension point | `_includes/metadata-hook.html` (new) |
| 3 | **Valid image structured data** — post-process the `jekyll-seo-tag` output so the BlogPosting `image` uses proper `ImageObject` casing and a valid `caption` property instead of the unrecognized `alt` | `_includes/head.html` |
| 4 | **Explicit AI-crawler policy** — welcome GPTBot, OAI-SearchBot, ChatGPT-User, PerplexityBot, ClaudeBot, Google-Extended, Amazonbot, Bingbot, … (keeps `Sitemap` + default allow) | `assets/robots.txt` (new local override) |
| 5 | **/llms.txt** — [llms.txt-convention](https://llmstxt.org) summary of the site, author, key links, and topics | `llms.txt` (new) |

## Before / after

> This is a **non-visual** PR — the rendered pages look identical, so page screenshots would show no difference. The meaningful before/after is the machine-readable output that search + AI engines consume.

**Post structured data (`/did-i-execute/`)**

_Before_ — one block, no author:
```jsonc
// BlogPosting only — no "author"
{"@type":"BlogPosting","headline":"Did I Execute?", ...}
```

_After_ — three blocks, attributed and valid:
```jsonc
{"@type":"BlogPosting","author":{"@type":"Person","name":"Akash Trehan","url":".../about/"},"image":{"caption":"...","url":"...","@type":"ImageObject"}, ...}
{"@type":"Person","name":"Akash Trehan","jobTitle":"...","worksFor":{"@type":"Organization","name":"Microsoft"},"knowsAbout":[...],"sameAs":[...]}
{"@type":"BreadcrumbList","itemListElement":[{"name":"Home"},{"name":"Did I Execute?"}]}
```
Plus `<meta name="author" content="Akash Trehan">` and `<meta name="twitter:creator" content="@theakashtrehan">`.

**robots.txt** — _before_: only `User-agent: *` + `Sitemap`. _After_: same defaults **plus** explicit `Allow: /` groups for the major AI answer-engine crawlers, making the "yes, please cite me" policy intentional.

**llms.txt** — _before_: none. _After_: served at `/llms.txt`.

## Structured-data validation

Validated the post's three JSON-LD blocks with the [Schema Markup Validator](https://validator.schema.org) — **0 errors, 0 warnings** across all three:

![schema.org validation](https://raw.githubusercontent.com/CodeMaxx/CodeMaxx.github.io/3c556a3/schema-validation.png)

- **BreadcrumbList** — 0 errors ✅
- **Person** — 0 errors ✅
- **BlogPosting** — 0 errors ✅

## Testing

- Production Jekyll build (`JEKYLL_ENV=production`) — clean, no conflicts/warnings.
- Verified generated `_site` output: posts emit valid `BlogPosting` (with author, `ImageObject`) + `Person` + `BreadcrumbList`; home emits `WebSite` + `Person`; `robots.txt` and `llms.txt` render with absolute URLs; sitemap (131 URLs) and feed unchanged.

## Follow-ups (not in this PR)

- Add the Google Search Console verification (Domain property via a DNS TXT record; no code change needed).
- Per-post TL;DR + FAQ sections (content authoring, lands with new posts).
