### PR TITLE
Mobile design polish: hero clip, page titles, search, nav, footer, socials

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -167,22 +167,18 @@ $tn-max: 1140px;
 .tn-mode #mode-toggle > svg {
   display: none;
 }
-:root[data-bs-theme='light'][data-theme-persisted]
+/* The trigger always shows the icon for the currently-resolved appearance
+   (sun for light, moon for dark). The theme JS always sets `data-bs-theme`
+   to a concrete 'light'/'dark' value (System resolves to one of them), so we
+   key off that rather than persisted-ness. The monitor/System glyph is kept
+   only for the System row inside the dropdown menu. */
+:root[data-bs-theme='dark'] .tn-mode #mode-toggle > [data-theme-mode='dark'] {
+  display: block;
+}
+:root:not([data-bs-theme='dark'])
   .tn-mode
   #mode-toggle
   > [data-theme-mode='light'] {
-  display: block;
-}
-:root[data-bs-theme='dark'][data-theme-persisted]
-  .tn-mode
-  #mode-toggle
-  > [data-theme-mode='dark'] {
-  display: block;
-}
-:root:not([data-theme-persisted])
-  .tn-mode
-  #mode-toggle
-  > [data-theme-mode='system'] {
   display: block;
 }
 /* Inline SVG icon (light mode): keep it aligned in the button and spaced
@@ -201,7 +197,11 @@ $tn-max: 1140px;
   display: none !important;
 }
 
-/* The theme renders #topbar-title for mobile; hide on desktop (brand covers it). */
+/* Hide the topbar page-title on all viewports: the brand covers identity in the
+   top-nav, and the page's own content heading (`.dynamic-title` / listing
+   title) carries the page title on every viewport. See the mobile block below,
+   which un-hides `.dynamic-title` so page-layout pages (All-Tags, 404) keep a
+   visible heading on phones. */
 #topbar-title {
   display: none;
 }
@@ -724,8 +724,59 @@ div[class^='language-'] .code-header {
   opacity: 0.85;
 }
 
+/* ---------- Footer social icons ---------- */
+/* The shared social-icons row (`social-icons.html`) is otherwise unstyled in
+   the footer: raw inline links render tiny (~13px) and gapless. Give them a
+   consistent size, spacing and hover accent (the hero row has its own boxed
+   styling via `.hero-socials`, so this only affects the footer). */
+.footer-socials {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.85rem;
+  font-size: 1.05rem;
+}
+.footer-socials a {
+  color: var(--text-muted-color) !important;
+  transition: color 0.15s ease;
+}
+.footer-socials a:hover {
+  color: var(--accent-1) !important;
+}
+/* The footer stacks into a column below Bootstrap's `lg` (992px) via
+   `flex-lg-row`, not at the 850px breakpoint the nav/search use. Center the
+   social row and let the footer grow to fit whenever it is stacked, so the
+   851-991px band matches phones (icons centered under the copyright, not
+   left-aligned against a centered copyright). */
+@media (max-width: 991.98px) {
+  footer {
+    height: auto;
+  }
+  .footer-socials {
+    justify-content: center;
+    margin-top: 1rem;
+  }
+  /* The theme anchors #back-to-top a fixed distance above the viewport bottom
+     sized for a 6rem footer; the now taller auto-height footer would poke up
+     under it and overlap the copyright. Raise the button clear of the footer. */
+  #back-to-top {
+    bottom: 7.5rem;
+  }
+}
+/* Ultra-narrow (< ~264px, below any mainstream device): the footer social row
+   wraps to two lines, making the footer ~150-170px tall, so lift the button
+   further to keep it clear of the copyright. */
+@media (max-width: 264px) {
+  #back-to-top {
+    bottom: 11rem;
+  }
+}
+
 /* ---------- Responsive nav ---------- */
-@media (max-width: 850px) {
+/* 849px (not 850) matches Chirpy's `bp.lt(lg)` == max-width: calc(850px - 1px),
+   so the mobile rules end exactly where the theme's desktop rules begin — no
+   1px band at 850px where both rulesets apply. */
+@media (max-width: 849px) {
   #topbar {
     flex-wrap: wrap;
     padding: 0 1rem;
@@ -739,12 +790,66 @@ div[class^='language-'] .code-header {
     padding-bottom: 0.4rem;
     justify-content: flex-start;
     -webkit-overflow-scrolling: touch;
+    /* Fade the trailing edge to signal the row scrolls horizontally when the
+       links overflow the viewport (the scrollbar is hidden on touch). */
+    -webkit-mask-image: linear-gradient(
+      to right,
+      #000 calc(100% - 1.5rem),
+      transparent
+    );
+    mask-image: linear-gradient(to right, #000 calc(100% - 1.5rem), transparent);
+    scrollbar-width: none;
+  }
+  .tn-nav::-webkit-scrollbar {
+    display: none;
   }
   #topbar-wrapper {
     height: auto;
   }
   .tn-nav .tn-link {
     white-space: nowrap;
+    /* Give the text-only nav links a ~44px tap height on touch devices. */
+    padding-top: 0.7rem;
+    padding-bottom: 0.7rem;
+  }
+  .tn-nav .tn-link.active::after {
+    bottom: 0;
+  }
+  /* Trailing scroll spacer so the last link can scroll clear of the edge fade
+     (otherwise "About" stays partly faded at maximum scroll). */
+  .tn-nav::after {
+    content: '';
+    flex: 0 0 1.5rem;
+  }
+
+  /* The content page heading carries the title on mobile (the topbar title is
+     hidden site-wide). The theme hides `.dynamic-title` below `lg`, so un-hide
+     it here or page-layout pages (All-Tags, 404) show no heading on phones. */
+  h1.dynamic-title {
+    display: block;
+  }
+  h1.dynamic-title ~ .content {
+    margin-top: 0;
+  }
+
+  /* ----- Mobile search mode ----- */
+  /* While search is open the theme adds `.d-block` to #search-cancel. Collapse
+     the top-nav to a clean, full-width search bar: drop the brand, the crammed
+     nav row and the (now redundant) theme toggle so only the field + Cancel
+     remain. */
+  #topbar:has(#search-cancel.d-block) .tn-brand,
+  #topbar:has(#search-cancel.d-block) .tn-nav,
+  #topbar:has(#search-cancel.d-block) .tn-mode {
+    display: none;
+  }
+  #topbar:has(#search-cancel.d-block) .tn-controls {
+    width: 100%;
+    margin-left: 0;
+  }
+  /* Don't let the results panel stretch to the full viewport height when it
+     only holds the Trending Tags hint — collapse the large empty gap below. */
+  #search-result-wrapper {
+    height: auto;
   }
 }
 
@@ -1095,15 +1200,27 @@ div[class^='language-'] .code-header {
   }
 
   /* ---------- Responsive ---------- */
-  @media (max-width: 850px) {
+  /* 849px matches Chirpy's `bp.lt(lg)`; see the responsive-nav note above. */
+  @media (max-width: 849px) {
     /* Prevent the blurred hero glow from overflowing the viewport (sideways
        scroll on phones). Clip horizontally without creating a scroll box. */
     overflow-x: clip;
 
     .landing-hero {
-      grid-template-columns: 1fr;
+      /* minmax(0, 1fr) lets the single column shrink below its content width
+         (grid children default to min-width:auto), preventing the H1/kicker
+         from overflowing and getting clipped by `overflow-x: clip` above. */
+      grid-template-columns: minmax(0, 1fr);
       text-align: center;
       gap: 1.5rem;
+    }
+    .hero-copy {
+      min-width: 0;
+    }
+    .hero-headline {
+      /* Defensive: break an over-long word rather than let it overflow the
+         clipped column on very narrow phones. */
+      overflow-wrap: break-word;
     }
     .hero-subtext {
       max-width: none;
@@ -1113,6 +1230,13 @@ div[class^='language-'] .code-header {
       flex-direction: column;
       align-items: center;
     }
+    .hero-socials {
+      /* 8 icons at 42px + gaps is ~403px, wider than a phone viewport, so the
+         row was clipped on both edges by `overflow-x: clip`. Let it wrap and
+         stay centered instead of losing the first/last icon. */
+      flex-wrap: wrap;
+      justify-content: center;
+    }
     .hero-docs {
       justify-content: center;
     }
@@ -1120,7 +1244,10 @@ div[class^='language-'] .code-header {
       order: -1;
     }
     .hero-photo {
-      max-width: 260px;
+      /* A tall 640x1024 portrait at 260px wide is ~416px tall and eats the
+         whole fold, pushing the kicker + headline (the value prop) below it.
+         Shrink it on phones so the headline leads. */
+      max-width: 180px;
     }
     .topic-grid {
       grid-template-columns: 1fr;


### PR DESCRIPTION
## Mobile design polish

Fixes the phone-only issues found in the mobile design review. **CSS-only** change (`assets/css/style.scss`); no layout/template edits. Closes beads **af2.37**, **af2.40**, and **af2.46**.

Every rule except the theme-glyph and footer-socials base styling lives inside `@media (max-width: 850px)`, so **desktop is unchanged** (verified below).

### What changed
| # | Task | Fix |
|---|------|-----|
| 1 | af2.37 | Landing hero H1/kicker were **clipped** on phones. Grid child couldn't shrink below its content width → overflowed and got cut by `overflow-x: clip`. Fix: `minmax(0,1fr)` + `.hero-copy { min-width:0 }`. |
| 2 | af2.40 | **Page titles restored** on mobile. Both `#topbar-title` (hidden site-wide) and the content `.dynamic-title` (theme hides it below `lg`) were hidden, so All-Tags & 404 had no heading on phones. Un-hide `.dynamic-title` on mobile — consistent with listing pages that already show their title in content. |
| 3 | af2.40 | **Mobile search** collapses to a clean full-width search bar (hide brand/nav/theme toggle) instead of a crammed nav row; results panel no longer stretches into a tall empty gap. |
| 4 | af2.40 | **Theme glyph** now shows the resolved appearance (sun/moon) instead of a monitor/System icon. Keyed off `data-bs-theme` not persisted-ness. |
| 5 | af2.40 | Scrollable mobile nav gets an **edge-fade** scroll affordance + trailing spacer, and **~44px tap targets**. |
| 6 | af2.40 | **Smaller mobile hero photo** so the headline leads the fold. |
| 7 | af2.46 | **Hero "Follow me on" clipped** (8 icons ~403px > viewport, no wrap → GitHub + RSS cut off). Let `.hero-socials` wrap and stay centered. |
| 8 | af2.46 | **Footer socials were unstyled** (~13px, gapless, left-aligned under a centered copyright). Style `.footer-socials` (size/gap/hover); on mobile center it + `footer { height:auto }` so the row isn't clipped by the theme's fixed 6rem footer. |

---

### Before / After (mobile, 390px)

**Home hero — clip fixed, headline leads, sun glyph (was monitor)**
| Before (live) | After (local) |
|---|---|
| <img src="https://github.com/CodeMaxx/CodeMaxx.github.io/releases/download/pr-assets/mobpr-home-mobile-before.png" width="320"> | <img src="https://github.com/CodeMaxx/CodeMaxx.github.io/releases/download/pr-assets/mobpr-home-mobile-after-v2.png" width="320"> |

**"Follow me on" — icons were clipped on both edges → now wrap, centered**
| Before (live) | After (local) |
|---|---|
| <img src="https://github.com/CodeMaxx/CodeMaxx.github.io/releases/download/pr-assets/mobpr-heromsocials-mobile-before.png" width="360"> | <img src="https://github.com/CodeMaxx/CodeMaxx.github.io/releases/download/pr-assets/mobpr-heromsocials-mobile-after-v2.png" width="360"> |

**Footer — tiny left-jammed icons → sized + centered under the copyright**
| Before (live) | After (local) |
|---|---|
| <img src="https://github.com/CodeMaxx/CodeMaxx.github.io/releases/download/pr-assets/mobpr-footer-mobile-before.png" width="360"> | <img src="https://github.com/CodeMaxx/CodeMaxx.github.io/releases/download/pr-assets/mobpr-footer-mobile-after-v2.png" width="360"> |

**All-Tags — "Tags" heading restored**
| Before (live) | After (local) |
|---|---|
| <img src="https://github.com/CodeMaxx/CodeMaxx.github.io/releases/download/pr-assets/mobpr-alltags-mobile-before.png" width="320"> | <img src="https://github.com/CodeMaxx/CodeMaxx.github.io/releases/download/pr-assets/mobpr-alltags-mobile-after-v2.png" width="320"> |

**404 — heading restored**
| Before (live) | After (local) |
|---|---|
| <img src="https://github.com/CodeMaxx/CodeMaxx.github.io/releases/download/pr-assets/mobpr-404-mobile-before.png" width="320"> | <img src="https://github.com/CodeMaxx/CodeMaxx.github.io/releases/download/pr-assets/mobpr-404-mobile-after-v2.png" width="320"> |

**Search — crammed nav + monitor glyph → clean full-width bar**
| Before (live) | After (local) | After: typing |
|---|---|---|
| <img src="https://github.com/CodeMaxx/CodeMaxx.github.io/releases/download/pr-assets/mobpr-search-mobile-before.png" width="240"> | <img src="https://github.com/CodeMaxx/CodeMaxx.github.io/releases/download/pr-assets/mobpr-search-mobile-after-v2.png" width="240"> | <img src="https://github.com/CodeMaxx/CodeMaxx.github.io/releases/download/pr-assets/mobpr-search-results-mobile-after-v2.png" width="240"> |

**Nav edge-fade at 320px (iPhone SE) — signals horizontal scroll**
<img src="https://github.com/CodeMaxx/CodeMaxx.github.io/releases/download/pr-assets/mobpr-home-320-after-v2.png" width="300">

---

### Desktop unchanged (verified)
| Home (light) | Home (dark) | All-Tags | Footer |
|---|---|---|---|
| <img src="https://github.com/CodeMaxx/CodeMaxx.github.io/releases/download/pr-assets/mobpr-home-desktop-after-v2.png" width="300"> | <img src="https://github.com/CodeMaxx/CodeMaxx.github.io/releases/download/pr-assets/mobpr-home-desktop-dark-after-v2.png" width="300"> | <img src="https://github.com/CodeMaxx/CodeMaxx.github.io/releases/download/pr-assets/mobpr-alltags-desktop-after-v2.png" width="300"> | <img src="https://github.com/CodeMaxx/CodeMaxx.github.io/releases/download/pr-assets/mobpr-footer-desktop-after-v2.png" width="300"> |

The theme-glyph fix (sun/moon, never monitor on the trigger) and the `.footer-socials` base styling are the only rules that touch desktop; the desktop footer is unchanged in layout (icons flush-right), with slightly improved icon spacing.

### Review-driven refinements
- Footer socials are centered for the **whole stacked-footer range (<992px)**, not just phones — the 851–991px band (Bootstrap keeps the footer column-stacked until `lg`=992px) had left-aligned icons under a centered copyright.
- **`#back-to-top` raised** on stacked-footer widths: it's anchored a fixed distance above the viewport sized for a 6rem footer, and the taller auto-height footer poked up under it and overlapped the copyright at ~320px.

  <img src="https://github.com/CodeMaxx/CodeMaxx.github.io/releases/download/pr-assets/mobpr-backtotop-320-after-v2.png" width="280">

- `.footer-socials` **wraps** to avoid horizontal overflow on ultra-narrow (<~264px) viewports; `#back-to-top` gets an extra lift below 264px so it still clears the taller two-row footer.
- Mobile breakpoints aligned to **Chirpy's `bp.lt(lg)` (`max-width: 849px`)** so mobile rules end exactly where the theme's desktop rules begin (no 1px overlap band at 850px).

### Testing
- Local production-mode build; verified at **240 / 320 / 360 / 390 / 414px** and **desktop 850 / 900 / 992 / 1280px**, light + dark.
- `document.scrollWidth == innerWidth` at all widths (incl. 240px) → **no horizontal overflow**.
- `#back-to-top` clears the footer copyright at 320px (no overlap).
- At exactly **850px** the layout is now fully desktop (2-col hero, single-row topbar, 340px photo) — no mixed ruleset.
- Two adversarial rubber-duck reviews (initial + a follow-up re-review of the refinements): **no high-severity issues**; every flagged item addressed, including an ultra-narrow (<264px) back-to-top lift.
- Hero socials wrap to a centered 2nd row (403px → 366px, all 8 icons visible).
- Nav tap height **45.9px** (≥44px); nav overflows and shows the fade at 320px; "About" clears the fade at max scroll.
- Search relayout is reversible on Cancel (brand/nav restored).
