### PR TITLE
Make listing cards consistent (uniform covers, read-time, count, mobile meta wrap)

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -78,6 +78,8 @@ refactor: true
     {% if page.subtitle %}
       <p class="listing-subtitle">{{ page.subtitle }}</p>
     {% endif %}
+    {% assign post_count = posts | size %}
+    <p class="listing-count">{{ post_count }} post{% unless post_count == 1 %}s{% endunless %}</p>
   </header>
 {% endif %}
 
@@ -94,49 +96,34 @@ refactor: true
         {% if post.redirect_to %}target="_blank" rel="noopener noreferrer"{% endif %}
         class="post-preview row g-0 flex-md-row-reverse"
       >
-        {% assign card_body_col = '12' %}
+        <div class="col-md-5">
+          <div class="card-media">
+            {% if post.image %}
+              {% assign src = post.image.path | default: post.image %}
 
-        {% if post.image %}
-          {% assign src = post.image.path | default: post.image %}
+              {% if post.media_subpath %}
+                {% unless src contains '://' %}
+                  {% assign src = post.media_subpath
+                    | append: '/'
+                    | append: src
+                    | replace: '///', '/'
+                    | replace: '//', '/'
+                  %}
+                {% endunless %}
+              {% endif %}
 
-          {% if post.media_subpath %}
-            {% unless src contains '://' %}
-              {% assign src = post.media_subpath
-                | append: '/'
-                | append: src
-                | replace: '///', '/'
-                | replace: '//', '/'
-              %}
-            {% endunless %}
-          {% endif %}
+              {% assign alt = post.image.alt | xml_escape | default: 'Preview image' %}
 
-          {% if post.image.lqip %}
-            {% assign lqip = post.image.lqip %}
-
-            {% if post.media_subpath %}
-              {% unless lqip contains 'data:' %}
-                {% assign lqip = post.media_subpath
-                  | append: '/'
-                  | append: lqip
-                  | replace: '///', '/'
-                  | replace: '//', '/'
-                %}
-              {% endunless %}
+              <img src="{{ src }}" alt="{{ alt }}" loading="lazy">
+            {% else %}
+              <span class="card-media-placeholder" aria-hidden="true">
+                <i class="fas fa-feather-pointed"></i>
+              </span>
             {% endif %}
-
-            {% assign lqip_attr = 'lqip="' | append: lqip | append: '"' %}
-          {% endif %}
-
-          {% assign alt = post.image.alt | xml_escape | default: 'Preview Image' %}
-
-          <div class="col-md-5">
-            <img src="{{ src }}" alt="{{ alt }}" {{ lqip_attr }}>
           </div>
+        </div>
 
-          {% assign card_body_col = '7' %}
-        {% endif %}
-
-        <div class="col-md-{{ card_body_col }}">
+        <div class="col-md-7">
           <div class="card-body d-flex flex-column">
             <h1 class="card-title my-2 mt-md-0">
               {{ post.title }}
@@ -153,21 +140,35 @@ refactor: true
             </div>
 
             <div class="post-meta flex-grow-1 d-flex align-items-end">
-              <div class="me-auto">
+              <div class="me-auto card-meta-items">
                 <!-- posted date -->
-                <i class="far fa-calendar fa-fw me-1"></i>
-                {% include datetime.html date=post.date lang=lang %}
+                <span class="meta-item">
+                  <i class="far fa-calendar fa-fw me-1"></i>
+                  {% include datetime.html date=post.date lang=lang %}
+                </span>
+
+                <!-- reading time (skip external redirects, which have no local content) -->
+                {% unless post.redirect_to %}
+                  <span class="meta-item">
+                    <i class="far fa-clock fa-fw me-1"></i>
+                    {% include read-time.html content=post.content prompt=true lang=lang %}
+                  </span>
+                {% endunless %}
 
                 <!-- points (CTF write-ups) -->
                 {% if post.points %}
-                  <i class="fas fa-trophy fa-fw me-1"></i>
-                  <span>{{ post.points }} pts</span>
+                  <span class="meta-item">
+                    <i class="fas fa-trophy fa-fw me-1"></i>
+                    <span>{{ post.points }} pts</span>
+                  </span>
                 {% endif %}
 
                 <!-- CTF challenge type (write-ups) -->
                 {% if post.ctf_category %}
-                  <i class="far fa-folder-open fa-fw me-1"></i>
-                  <span class="categories">{{ post.ctf_category }}</span>
+                  <span class="meta-item">
+                    <i class="far fa-folder-open fa-fw me-1"></i>
+                    <span class="categories">{{ post.ctf_category }}</span>
+                  </span>
                 {% endif %}
               </div>
 

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -630,13 +630,91 @@ div[class^='language-'] .code-header {
   font-size: 1.05rem;
   margin: 0;
 }
+.listing-count {
+  margin: 0.6rem 0 0;
+  font-size: 0.82rem;
+  font-weight: 500;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  color: var(--text-muted-color);
+}
 .listing #post-list {
   max-width: 1080px;
   margin-left: auto;
   margin-right: auto;
 }
 
-/* Non-clickable tag pills on listing cards (card itself is the link). */
+/* ---------- Uniform listing thumbnails ----------
+   Every card gets a fixed 16:9 cover so the grid reads as a deliberate
+   two-column layout regardless of whether a post declares an image. Posts
+   without an image fall back to a branded accent placeholder instead of
+   collapsing to a full-width text row. A plain <img loading="lazy"> is used
+   (no theme LQIP shimmer) so cards never get stuck on the gray --img-bg
+   gradient placeholder. */
+#post-list .post-preview .card-media {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  aspect-ratio: 16 / 9;
+  overflow: hidden;
+  background: var(--img-bg);
+  border-radius: 12px 12px 0 0;
+}
+#post-list .post-preview .card-media .preview-img {
+  width: 100%;
+  height: 100%;
+  aspect-ratio: auto;
+  border-radius: inherit;
+}
+#post-list .post-preview .card-media img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+  border-radius: inherit;
+}
+#post-list .post-preview .card-media-placeholder {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  background: var(--accent-grad);
+  color: #fff;
+  font-size: 2rem;
+  opacity: 0.92;
+}
+@media (min-width: 768px) {
+  #post-list .post-preview .card-media {
+    aspect-ratio: auto;
+    min-height: 100%;
+    border-radius: 0 12px 12px 0;
+  }
+}
+
+/* Listing card meta row: let the date / read-time / points / category groups
+   wrap onto multiple lines on narrow screens instead of clipping the trailing
+   items with the theme's single-line ellipsis. Each group is a nowrap
+   .meta-item so wrapping only ever happens between groups, never mid-label.
+   Matches the theme selector specificity and wins by source order. */
+#post-list .card .card-body .post-meta > div.card-meta-items {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  column-gap: 1.3rem;
+  row-gap: 0.35rem;
+  overflow: visible;
+  white-space: normal;
+  text-overflow: clip;
+}
+#post-list .post-preview .post-meta .meta-item {
+  white-space: nowrap;
+}
+
+/* Tag pills on listing cards. Match the site-wide 6px accent-outline pill
+   (.post-tag-pill / #tags .tag) so the tag language stays consistent. The
+   whole card is the link, so these are non-interactive spans with no hover
+   state of their own. */
 .card-tags {
   display: flex;
   flex-wrap: wrap;


### PR DESCRIPTION
## Summary

Makes the shared listing card (`#post-list`) consistent across **Blog**, **Write-ups**, and **Projects** (beads `af2.39`). Previously the grid looked accidental: cards flipped between image+text and full-width text-only depending on the data, thumbnails had no fixed aspect ratio, and in light mode not-yet-loaded covers showed a stark gray box that read as a broken image.

## What changed

- **Uniform thumbnail policy.** Every card now renders a fixed **16:9 cover**. Posts with an image show it (`object-fit: cover`); posts without one get a branded accent-gradient placeholder instead of collapsing to a full-width text row. The grid is now a deliberate two-column layout regardless of the underlying data.
- **Fixed aspect ratio.** Added `#post-list .post-preview .card-media` rules (aspect-ratio, `object-fit: cover`, rounded corners) and normalized the theme-injected `.preview-img` wrapper to fill the box, so card heights no longer vary wildly and wide banners/logos sit in a consistent frame.
- **No more gray "broken image" boxes.** Dropped the broken LQIP attribute path and render a plain `<img loading="lazy">`, so cards no longer get stuck on the theme's white→gray `--img-bg` shimmer placeholder.
- **Reading time + post count.** Added reading time to the card meta row (skipped for external `redirect_to` posts, which have no local content) and an "N posts" count to each listing header.
- **Meta row wraps on mobile.** Each meta field (date, reading time, points, category) is now a `nowrap` span, and the meta row wraps between fields on narrow screens instead of clipping the trailing item with the theme's single-line ellipsis. This keeps the CTF category visible on write-up cards once reading time is added.
- **Tag pills stay consistent.** The card tags keep the site-wide 6px accent-outline pill used by post tags, the tags index, and search results — no bespoke chip style is introduced.

Only `_layouts/home.html` and `assets/css/style.scss` are touched.

## Testing

- ✅ Production Jekyll build (`JEKYLL_ENV=production`) succeeds.
- ✅ Verified Blog (13), Write-ups (36), and Projects (8) in a local production build, in **both light and dark mode**: uniform 16:9 covers, gradient placeholders for image-less posts, reading time and post counts present, consistent accent-outline tag pills.
- ✅ Adversarial **mobile pass at 390px** (light and dark): covers stack above the text, the meta row wraps without clipping the category, and tag pills stay consistent. This caught and fixed a meta-row truncation that adding reading time had introduced on write-up cards.
- ✅ Confirmed all lazy covers load and their shimmer clears on scroll, and that external redirect posts correctly omit reading time.

## Before / After

### Blog — light mode

**Before (live site):** cards flip between two-column and text-only, image-less posts collapse to a full-width text row, three light-mode covers render as empty gray boxes, no reading time or count.

![Blog before light](https://github.com/CodeMaxx/CodeMaxx.github.io/releases/download/pr-assets/af2-39-blog-prod-light-full.png)

**After (local build):** uniform 16:9 covers, branded placeholders for image-less posts, "13 posts" count, reading time, consistent accent-outline tags.

![Blog after light](https://github.com/CodeMaxx/CodeMaxx.github.io/releases/download/pr-assets/af2-39-blog-local-light-full.png)

### Blog — dark mode

**Before (live site):**

![Blog before dark](https://github.com/CodeMaxx/CodeMaxx.github.io/releases/download/pr-assets/af2-39-blog-prod-dark-full.png)

**After (local build):**

![Blog after dark](https://github.com/CodeMaxx/CodeMaxx.github.io/releases/download/pr-assets/af2-39-blog-local-dark-full.png)

### Blog — mobile (390px)

**Before (live site):** image-less posts collapse to text-only rows and card layout is uneven.

![Blog before mobile](https://github.com/CodeMaxx/CodeMaxx.github.io/releases/download/pr-assets/af2-39-blog-mobile-before.png)

**After (local build):** uniform stacked covers, branded placeholders, reading time, and a meta row that wraps cleanly.

![Blog after mobile](https://github.com/CodeMaxx/CodeMaxx.github.io/releases/download/pr-assets/af2-39-blog-mobile-after.png)

### Projects & Write-ups — after (local build)

Image-less projects get the branded placeholder; the redirect-only "Machine Learning - Coursera" write-up gets a placeholder and correctly omits reading time. On write-up cards the meta row (date · read time · points · category) wraps instead of truncating.

![Projects after](https://github.com/CodeMaxx/CodeMaxx.github.io/releases/download/pr-assets/af2-39-projects-local-light-full.png)

![Write-ups after](https://github.com/CodeMaxx/CodeMaxx.github.io/releases/download/pr-assets/af2-39-writeups-top.png)
