### PR TITLE
Polish post reading: narrower measure, clean headings, idiomatic callouts

### DIFF
--- a/_includes/related-posts.html
+++ b/_includes/related-posts.html
@@ -1,7 +1,7 @@
-<!-- Recommend the other 3 posts according to the tags and categories of the current post. -->
+<!-- Recommend related posts according to the tags and categories of the current post. -->
 
 <!-- The total size of related posts -->
-{% assign TOTAL_SIZE = 3 %}
+{% assign TOTAL_SIZE = 2 %}
 
 <!-- An random integer that bigger than 0 -->
 {% assign TAG_SCORE = 1 %}
@@ -74,7 +74,7 @@
     <h3 class="mb-4" id="related-label">
       {{- site.data.locales[include.lang].post.relate_posts -}}
     </h3>
-    <nav class="row row-cols-1 row-cols-md-2 row-cols-xl-3 g-4 mb-4">
+    <nav class="row row-cols-1 row-cols-md-2 g-4 mb-4">
       {% for post in relate_posts %}
         <article class="col">
           <a

--- a/_posts/2016-05-31-writeup-overthewire-bandit-level00.md
+++ b/_posts/2016-05-31-writeup-overthewire-bandit-level00.md
@@ -16,17 +16,11 @@ ctf_category: Wargame
 description: "Bandit Level 0 → 1: logging into SSH and reading a file with cat"
 ---
 
-#### Level Goal:
+> **Level goal:** The password for the next level is stored in a file called **readme** located in the home directory. Use this password to log into bandit1 using SSH. Whenever you find a password for a level, use SSH to log into that level and continue the game.
 
->The password for the next level is stored in a file called **readme** located in the home directory. Use this password to log into bandit1 using SSH. Whenever you find a password for a level, use SSH to log into that level and continue the game.
+**Commands you may need:** `ls`, `cd`, `cat`, `file`, `du`, `find`
 
-#### Commands you may need to solve this level
-
->ls, cd, cat, file, du, find
-
-#### Helpful Reading Material
-
->None
+**Helpful reading:** None
 
 ## Write-up
 
@@ -44,4 +38,5 @@ Then look at the contents of `readme` file to get the password to the next level
 bandit0@melinda:~$ cat readme
 ~~~
 
-#### Level 1 password: `boJ9jbbUNNfktd78OOpsqOltutMc3MY1`
+> **Level 1 password:** `boJ9jbbUNNfktd78OOpsqOltutMc3MY1`
+{: .prompt-tip }

--- a/_posts/2016-05-31-writeup-overthewire-bandit-level01.md
+++ b/_posts/2016-05-31-writeup-overthewire-bandit-level01.md
@@ -16,18 +16,14 @@ ctf_category: Wargame
 description: "Bandit Level 1 → 2: reading a file named with a dash using a path prefix"
 ---
 
-#### Level Goal:
+> **Level goal:** The password for the next level is stored in a file called `-` located in the home directory
 
->The password for the next level is stored in a file called `-` located in the home directory
+**Commands you may need:** `ls`, `cd`, `cat`, `file`, `du`, `find`
 
-#### Commands you may need to solve this level
+**Helpful reading:**
 
->ls, cd, cat, file, du, find
-
-#### Helpful Reading Material
-
->[Google Search for "dashed filename"](https://www.google.com/search?q=dashed+filename)
-[Advanced Bash-scripting Guide - Chapter 3 - Special Characters](https://tldp.org/LDP/abs/html/special-chars.html)
+- [Google Search for "dashed filename"](https://www.google.com/search?q=dashed+filename)
+- [Advanced Bash-scripting Guide - Chapter 3 - Special Characters](https://tldp.org/LDP/abs/html/special-chars.html)
 
 ## Write-up
 
@@ -35,4 +31,5 @@ This was a bit tricky. The filename was `-`. A simple `cat -` didn't work. This 
 
 Thus I used `cat ~/-` to read from the file.
 
-#### Level 2 password: `CV1DtqXWVFXTvM2F0k09SHz0YwRINYA9`
+> **Level 2 password:** `CV1DtqXWVFXTvM2F0k09SHz0YwRINYA9`
+{: .prompt-tip }

--- a/_posts/2016-05-31-writeup-overthewire-bandit-level02.md
+++ b/_posts/2016-05-31-writeup-overthewire-bandit-level02.md
@@ -16,17 +16,13 @@ ctf_category: Wargame
 description: "Bandit Level 2 → 3: reading a filename with spaces using quotes or backslash"
 ---
 
-#### Level Goal:
+> **Level goal:** The password for the next level is stored in a file called spaces in this filename located in the home directory
 
->The password for the next level is stored in a file called spaces in this filename located in the home directory
+**Commands you may need:** `ls`, `cd`, `cat`, `file`, `du`, `find`
 
-#### Commands you may need to solve this level
+**Helpful reading:**
 
->ls, cd, cat, file, du, find
-
-#### Helpful Reading Material
-
->[Google Search for “spaces in filename”](https://www.google.com/search?q=spaces+in+filename)
+- [Google Search for “spaces in filename”](https://www.google.com/search?q=spaces+in+filename)
 
 ## Write-up
 
@@ -34,4 +30,5 @@ This was simple enough since **Tab completion** was enabled. If that would not b
 
 Thus I used `cat spaces\ in\ this\ filename` to read from the file.
 
-#### Level 3 password: `UmHadQclWmgdLOKQ3YNgjWxGoRMb5luK`
+> **Level 3 password:** `UmHadQclWmgdLOKQ3YNgjWxGoRMb5luK`
+{: .prompt-tip }

--- a/_posts/2016-05-31-writeup-overthewire-bandit-level03.md
+++ b/_posts/2016-05-31-writeup-overthewire-bandit-level03.md
@@ -16,17 +16,11 @@ ctf_category: Wargame
 description: "Bandit Level 3 → 4: finding and reading a hidden file with ls -a"
 ---
 
-#### Level Goal:
+> **Level goal:** The password for the next level is stored in a hidden file in the inhere directory.
 
->The password for the next level is stored in a hidden file in the inhere directory.
+**Commands you may need:** `ls`, `cd`, `cat`, `file`, `du`, `find`
 
-#### Commands you may need to solve this level
-
->ls, cd, cat, file, du, find
-
-#### Helpful Reading Material
-
->None
+**Helpful reading:** None
 
 ## Write-up
 
@@ -38,4 +32,5 @@ bandit3@melinda:~$ ls inhere/
 
 This shows a `.hidden` file. Files with names starting with a `.`(dot) automatically get hidden in Unix.<br> `cat inhere/.hidden` reveals the password for the next level.
 
-#### Level 4 password: `pIwrPrtPN36QITSp3EQaw936yaFoFgAB`
+> **Level 4 password:** `pIwrPrtPN36QITSp3EQaw936yaFoFgAB`
+{: .prompt-tip }

--- a/_posts/2016-05-31-writeup-overthewire-bandit-level04.md
+++ b/_posts/2016-05-31-writeup-overthewire-bandit-level04.md
@@ -16,17 +16,11 @@ ctf_category: Wargame
 description: "Bandit Level 4 → 5: using the file command to find the only human-readable file"
 ---
 
-#### Level Goal:
+> **Level goal:** The password for the next level is stored in the only human-readable file in the inhere directory. Tip: if your terminal is messed up, try the “reset” command.
 
->The password for the next level is stored in the only human-readable file in the inhere directory. Tip: if your terminal is messed up, try the “reset” command.
+**Commands you may need:** `ls`, `cd`, `cat`, `file`, `du`, `find`
 
-#### Commands you may need to solve this level
-
->ls, cd, cat, file, du, find
-
-#### Helpful Reading Material
-
->None
+**Helpful reading:** None
 
 ## Write-up
 
@@ -57,4 +51,5 @@ inhere/-file02: data
 
 Thus `inhere/-file07` is the file we are looking for. `cat inhere/-file07` gives the password for the next level.
 
-#### Level 5 password: `koReBOKuIDDepwhWk7jZC0RTdopnAYKh`
+> **Level 5 password:** `koReBOKuIDDepwhWk7jZC0RTdopnAYKh`
+{: .prompt-tip }

--- a/_posts/2016-05-31-writeup-overthewire-bandit-level05.md
+++ b/_posts/2016-05-31-writeup-overthewire-bandit-level05.md
@@ -16,17 +16,11 @@ ctf_category: Wargame
 description: "Bandit Level 5 → 6: using find with size and non-executable flags to locate the password"
 ---
 
-#### Level Goal:
+> **Level goal:** The password for the next level is stored in a file somewhere under the inhere directory and has all of the following properties: - human-readable - 1033 bytes in size - not executable
 
->The password for the next level is stored in a file somewhere under the inhere directory and has all of the following properties: - human-readable - 1033 bytes in size - not executable
+**Commands you may need:** `ls`, `cd`, `cat`, `file`, `du`, `find`
 
-#### Commands you may need to solve this level
-
->ls, cd, cat, file, du, find
-
-#### Helpful Reading Material
-
->None
+**Helpful reading:** None
 
 ## Write-up
 
@@ -50,4 +44,5 @@ Getting two exact same outputs was eerie. After some investigation I found out t
 
 Thus a simple `find inhere -size 1033c -print` in the home directory would have done the job. `cat ~/inhere/maybeinhere07/.file2` gives the password.
 
-#### Level 6 password: `DXjZPULLxYr17uwoI01bNLQbtFemEgo7`
+> **Level 6 password:** `DXjZPULLxYr17uwoI01bNLQbtFemEgo7`
+{: .prompt-tip }

--- a/_posts/2016-05-31-writeup-overthewire-bandit-level06.md
+++ b/_posts/2016-05-31-writeup-overthewire-bandit-level06.md
@@ -16,17 +16,11 @@ ctf_category: Wargame
 description: "Bandit Level 6 → 7: searching the whole server by owner, group, and size with find"
 ---
 
-#### Level Goal:
+> **Level goal:** The password for the next level is stored somewhere on the server and has all of the following properties: - owned by user bandit7 - owned by group bandit6 - 33 bytes in size
 
->The password for the next level is stored somewhere on the server and has all of the following properties: - owned by user bandit7 - owned by group bandit6 - 33 bytes in size
+**Commands you may need:** `ls`, `cd`, `cat`, `file`, `du`, `find`, `grep`
 
-#### Commands you may need to solve this level
-
->ls, cd, cat, file, du, find, grep
-
-#### Helpful Reading Material
-
->None
+**Helpful reading:** None
 
 ## Write-up
 
@@ -55,4 +49,5 @@ cat `find . -size 33c -group bandit6 -user bandit7 2>/dev/null`
 
 So what `2>/dev/null` does is, it redirects all standard errors like `No such file or directory` and `Permission denied` to `/dev/null` where `null` acts as a special device which discards all information written to it. Thus we only get the one required file as output which I sent as input to `cat` to see its contents.
 
-#### Level 7 password: `HKBPTKQnIay4Fw76bEy8PVxKEDQRKTzs`
+> **Level 7 password:** `HKBPTKQnIay4Fw76bEy8PVxKEDQRKTzs`
+{: .prompt-tip }

--- a/_posts/2016-05-31-writeup-overthewire-bandit-level07.md
+++ b/_posts/2016-05-31-writeup-overthewire-bandit-level07.md
@@ -16,17 +16,11 @@ ctf_category: Wargame
 description: "Bandit Level 7 → 8: extracting a password next to the word 'millionth' with grep"
 ---
 
-#### Level Goal:
+> **Level goal:** The password for the next level is stored in the file **data.txt** next to the word **millionth**
 
->The password for the next level is stored in the file **data.txt** next to the word **millionth**
+**Commands you may need:** `grep`, `sort`, `uniq`, `strings`, `base64`, `tr`, `tar`, `gzip`, `bzip2`, `xxd`
 
-#### Commands you may need to solve this level
-
->grep, sort, uniq, strings, base64, tr, tar, gzip, bzip2, xxd
-
-#### Helpful Reading Material
-
->None
+**Helpful reading:** None
 
 ## Write-up
 
@@ -38,4 +32,5 @@ cat data.txt | grep millionth
 
 This gives the password.
 
-#### Level 8 password: `cvX2JJa4CFALtqS87jk27qwqGhBM9plV`
+> **Level 8 password:** `cvX2JJa4CFALtqS87jk27qwqGhBM9plV`
+{: .prompt-tip }

--- a/_posts/2016-05-31-writeup-overthewire-bandit-level08.md
+++ b/_posts/2016-05-31-writeup-overthewire-bandit-level08.md
@@ -16,17 +16,13 @@ ctf_category: Wargame
 description: "Bandit Level 8 → 9: finding the only unique line in a file using sort and uniq -u"
 ---
 
-#### Level Goal:
+> **Level goal:** The password for the next level is stored in the file data.txt and is the only line of text that occurs only once
 
->The password for the next level is stored in the file data.txt and is the only line of text that occurs only once
+**Commands you may need:** `grep`, `sort`, `uniq`, `strings`, `base64`, `tr`, `tar`, `gzip`, `bzip2`, `xxd`
 
-#### Commands you may need to solve this level
+**Helpful reading:**
 
->grep, sort, uniq, strings, base64, tr, tar, gzip, bzip2, xxd
-
-#### Helpful Reading Material
-
->~~[The unix commandline: pipes and redirects](http://www.westwind.com/reference/os-x/commandline/pipes.html)~~ *(Site no longer active)*
+- ~~[The unix commandline: pipes and redirects](http://www.westwind.com/reference/os-x/commandline/pipes.html)~~ *(Site no longer active)*
 
 ## Write-up
 
@@ -42,4 +38,5 @@ Hence I got the password.
 sort data.txt | uniq -u
 ~~~
 
-#### Level 9 password: `UsvVyFSfZZWbi6wgC7dAFyFuR6jQQUhR`
+> **Level 9 password:** `UsvVyFSfZZWbi6wgC7dAFyFuR6jQQUhR`
+{: .prompt-tip }

--- a/_posts/2016-05-31-writeup-overthewire-bandit-level09.md
+++ b/_posts/2016-05-31-writeup-overthewire-bandit-level09.md
@@ -16,17 +16,11 @@ ctf_category: Wargame
 description: "Bandit Level 9 → 10: using strings to extract human-readable text from a binary file"
 ---
 
-#### Level Goal:
+> **Level goal:** The password for the next level is stored in the file data.txt in one of the few human-readable strings, beginning with several ‘=’ characters.
 
->The password for the next level is stored in the file data.txt in one of the few human-readable strings, beginning with several ‘=’ characters.
+**Commands you may need:** `grep`, `sort`, `uniq`, `strings`, `base64`, `tr`, `tar`, `gzip`, `bzip2`, `xxd`
 
-#### Commands you may need to solve this level
-
->grep, sort, uniq, strings, base64, tr, tar, gzip, bzip2, xxd
-
-#### Helpful Reading Material
-
->None
+**Helpful reading:** None
 
 ## Write-up
 
@@ -38,4 +32,5 @@ bandit9@melinda:~$ strings data.txt | grep ======
 
 ![output](/assets/images/OverTheWire/Bandit/level9_output.png)
 
-#### Level 10 password: `truKLdjsbJ5g7yyJ2X2R0o3a5HQJFuLk`
+> **Level 10 password:** `truKLdjsbJ5g7yyJ2X2R0o3a5HQJFuLk`
+{: .prompt-tip }

--- a/_posts/2016-05-31-writeup-overthewire-bandit-level10.md
+++ b/_posts/2016-05-31-writeup-overthewire-bandit-level10.md
@@ -16,17 +16,13 @@ ctf_category: Wargame
 description: "Bandit Level 10 → 11: decoding base64-encoded data with the base64 command"
 ---
 
-#### Level Goal:
+> **Level goal:** The password for the next level is stored in the file data.txt, which contains base64 encoded data
 
->The password for the next level is stored in the file data.txt, which contains base64 encoded data
+**Commands you may need:** `grep`, `sort`, `uniq`, `strings`, `base64`, `tr`, `tar`, `gzip`, `bzip2`, `xxd`
 
-#### Commands you may need to solve this level
+**Helpful reading:**
 
->grep, sort, uniq, strings, base64, tr, tar, gzip, bzip2, xxd
-
-#### Helpful Reading Material
-
->[Base64 on Wikipedia](https://en.wikipedia.org/wiki/Base64)
+- [Base64 on Wikipedia](https://en.wikipedia.org/wiki/Base64)
 
 ## Write-up
 
@@ -36,4 +32,5 @@ I used the pre-installed base64 decoder to get the passoword.
 bandit10@melinda:~$ cat data.txt | base64 --decode
 ~~~
 
-#### Level 11 password: `IFukwKGsFW8MOq3IRFqrxE1hxTNEbUPR`
+> **Level 11 password:** `IFukwKGsFW8MOq3IRFqrxE1hxTNEbUPR`
+{: .prompt-tip }

--- a/_posts/2016-05-31-writeup-overthewire-bandit-level11.md
+++ b/_posts/2016-05-31-writeup-overthewire-bandit-level11.md
@@ -16,17 +16,13 @@ ctf_category: Wargame
 description: "Bandit Level 11 → 12: decoding a ROT13 cipher using the tr command"
 ---
 
-#### Level Goal:
+> **Level goal:** The password for the next level is stored in the file data.txt, where all lowercase (a-z) and uppercase (A-Z) letters have been rotated by 13 positions
 
->The password for the next level is stored in the file data.txt, where all lowercase (a-z) and uppercase (A-Z) letters have been rotated by 13 positions
+**Commands you may need:** `grep`, `sort`, `uniq`, `strings`, `base64`, `tr`, `tar`, `gzip`, `bzip2`, `xxd`
 
-#### Commands you may need to solve this level
+**Helpful reading:**
 
->grep, sort, uniq, strings, base64, tr, tar, gzip, bzip2, xxd
-
-#### Helpful Reading Material
-
->[Rot13 on Wikipedia](https://en.wikipedia.org/wiki/Rot13)
+- [Rot13 on Wikipedia](https://en.wikipedia.org/wiki/Rot13)
 
 ## Write-up
 
@@ -38,4 +34,5 @@ Another method is using the `tr` command for rotation by 13, to get the password
 bandit11@melinda:~$ cat data.txt | tr 'n-za-mN-ZA-M' 'a-zA-Z'
 ~~~
 
-#### Level 12 password: `5Te8Y4drgCRfCx8ugdwuEX8KFC6k2EUu`
+> **Level 12 password:** `5Te8Y4drgCRfCx8ugdwuEX8KFC6k2EUu`
+{: .prompt-tip }

--- a/_posts/2016-05-31-writeup-overthewire-bandit-level12.md
+++ b/_posts/2016-05-31-writeup-overthewire-bandit-level12.md
@@ -16,17 +16,13 @@ ctf_category: Wargame
 description: "Bandit Level 12 → 13: decompressing a repeatedly-compressed hexdump with xxd, gzip, bzip2, and tar"
 ---
 
-#### Level Goal:
+> **Level goal:** The password for the next level is stored in the file data.txt, which is a hexdump of a file that has been repeatedly compressed. For this level it may be useful to create a directory under /tmp in which you can work using mkdir. For example: mkdir /tmp/myname123. Then copy the datafile using cp, and rename it using mv (read the manpages!)
 
->The password for the next level is stored in the file data.txt, which is a hexdump of a file that has been repeatedly compressed. For this level it may be useful to create a directory under /tmp in which you can work using mkdir. For example: mkdir /tmp/myname123. Then copy the datafile using cp, and rename it using mv (read the manpages!)
+**Commands you may need:** `grep`, `sort`, `uniq`, `strings`, `base64`, `tr`, `tar`, `gzip`, `bzip2`, `xxd`, `mkdir`, `cp`, `mv`
 
-#### Commands you may need to solve this level
+**Helpful reading:**
 
->grep, sort, uniq, strings, base64, tr, tar, gzip, bzip2, xxd, mkdir, cp, mv
-
-#### Helpful Reading Material
-
->[Hex dump on Wikipedia](https://en.wikipedia.org/wiki/Hex_dump)
+- [Hex dump on Wikipedia](https://en.wikipedia.org/wiki/Hex_dump)
 
 ## Write-up
 
@@ -49,4 +45,5 @@ So the given file was a hexdump. I used `xxd -r <filename>` to reverse it and se
 
 ***If you have a method to automate this stuff to make it easier, please comment below or <a href="#" onclick="location.href='mailto:' + 'me' + '@' + 'akashtrehan.com'; return false;">email me</a>.***
 
-#### Level 13 password: `8ZjyCRiBWFYkneahHwxCv3wb2a1ORpYL`
+> **Level 13 password:** `8ZjyCRiBWFYkneahHwxCv3wb2a1ORpYL`
+{: .prompt-tip }

--- a/_posts/2016-05-31-writeup-overthewire-bandit-level13.md
+++ b/_posts/2016-05-31-writeup-overthewire-bandit-level13.md
@@ -16,17 +16,13 @@ ctf_category: Wargame
 description: "Bandit Level 13 → 14: using an SSH private key to log in without a password"
 ---
 
-#### Level Goal:
+> **Level goal:** The password for the next level is stored in /etc/bandit_pass/bandit14 and can only be read by user bandit14. For this level, you don’t get the next password, but you get a private SSH key that can be used to log into the next level. Note: localhost is a hostname that refers to the machine you are working on
 
->The password for the next level is stored in /etc/bandit_pass/bandit14 and can only be read by user bandit14. For this level, you don’t get the next password, but you get a private SSH key that can be used to log into the next level. Note: localhost is a hostname that refers to the machine you are working on
+**Commands you may need:** `ssh`, `telnet`, `nc`, `openssl`, `s_client`, `nmap`
 
-#### Commands you may need to solve this level
+**Helpful reading:**
 
->ssh, telnet, nc, openssl, s_client, nmap
-
-#### Helpful Reading Material
-
->[SSH/OpenSSH/Keys](https://help.ubuntu.com/community/SSH/OpenSSH/Keys)
+- [SSH/OpenSSH/Keys](https://help.ubuntu.com/community/SSH/OpenSSH/Keys)
 
 ## Write-up
 
@@ -53,4 +49,5 @@ cat /etc/bandit_pass/bandit14
 
 You can now log into Level 14 with this password without the need of the private ssh keys.
 
-#### Level 14 password: `4wcYUJFw0k0XLShlDzztnTBHiqxU3b3e`
+> **Level 14 password:** `4wcYUJFw0k0XLShlDzztnTBHiqxU3b3e`
+{: .prompt-tip }

--- a/_posts/2016-05-31-writeup-overthewire-bandit-level14.md
+++ b/_posts/2016-05-31-writeup-overthewire-bandit-level14.md
@@ -16,22 +16,18 @@ ctf_category: Wargame
 description: "Bandit Level 14 → 15: submitting a password to a localhost port using netcat"
 ---
 
-#### Level Goal:
+> **Level goal:** The password for the next level can be retrieved by submitting the password of the current level to **port 30000 on localhost**.
 
->The password for the next level can be retrieved by submitting the password of the current level to **port 30000 on localhost**.
+**Commands you may need:** `ssh`, `telnet`, `nc`, `openssl`, `s_client`, `nmap`
 
-#### Commands you may need to solve this level
+**Helpful reading:**
 
->ssh, telnet, nc, openssl, s_client, nmap
-
-#### Helpful Reading Material
-
->[How the Internet works in 5 minutes (YouTube)](https://www.youtube.com/watch?v=7_LPdttKXPc)(Not completely accurate, but good enough for beginners)
-[IP Addresses](https://computer.howstuffworks.com/web-server5.htm)
-[IP Address on Wikipedia](https://en.wikipedia.org/wiki/IP_address)
-[Localhost on Wikipedia](https://en.wikipedia.org/wiki/Localhost)
-[Ports](https://computer.howstuffworks.com/web-server8.htm)
-[Port (computer networking) on Wikipedia](https://en.wikipedia.org/wiki/Port_(computer_networking))
+- [How the Internet works in 5 minutes (YouTube)](https://www.youtube.com/watch?v=7_LPdttKXPc)(Not completely accurate, but good enough for beginners)
+- [IP Addresses](https://computer.howstuffworks.com/web-server5.htm)
+- [IP Address on Wikipedia](https://en.wikipedia.org/wiki/IP_address)
+- [Localhost on Wikipedia](https://en.wikipedia.org/wiki/Localhost)
+- [Ports](https://computer.howstuffworks.com/web-server8.htm)
+- [Port (computer networking) on Wikipedia](https://en.wikipedia.org/wiki/Port_(computer_networking))
 
 ## Write-up
 
@@ -49,4 +45,5 @@ echo 4wcYUJFw0k0XLShlDzztnTBHiqxU3b3e | nc localhost 30000
 
 ![nc_command](/assets/images/OverTheWire/Bandit/nc_command.png)
 
-#### Level 15 password: `BfMYroe26WYalil77FoDi9qh59eK5xNr`
+> **Level 15 password:** `BfMYroe26WYalil77FoDi9qh59eK5xNr`
+{: .prompt-tip }

--- a/_posts/2016-05-31-writeup-overthewire-bandit-level15.md
+++ b/_posts/2016-05-31-writeup-overthewire-bandit-level15.md
@@ -16,20 +16,17 @@ ctf_category: Wargame
 description: "Bandit Level 15 → 16: submitting a password over SSL using openssl s_client"
 ---
 
-#### Level Goal:
+> **Level goal:** The password for the next level can be retrieved by submitting the password of the current level to port 30001 on localhost using SSL encryption.
 
->The password for the next level can be retrieved by submitting the password of the current level to port 30001 on localhost using SSL encryption.
+> Helpful note: Getting “HEARTBEATING” and “Read R BLOCK”? Use -ign_eof and read the “CONNECTED COMMANDS” section in the manpage. Next to ‘R’ and ‘Q’, the ‘B’ command also works in this version of that command…
+{: .prompt-warning }
 
-**Helpful note: Getting “HEARTBEATING” and “Read R BLOCK”? Use -ign_eof and read the “CONNECTED COMMANDS” section in the manpage. Next to ‘R’ and ‘Q’, the ‘B’ command also works in this version of that command…**
+**Commands you may need:** `ssh`, `telnet`, `nc`, `openssl`, `s_client`, `nmap`
 
-#### Commands you may need to solve this level
+**Helpful reading:**
 
->ssh, telnet, nc, openssl, s_client, nmap
-
-#### Helpful Reading Material
-
->[Secure Socket Layer/Transport Layer Security on Wikipedia](https://en.wikipedia.org/wiki/Secure_Socket_Layer)
-[OpenSSL Cookbook - Testing with OpenSSL](https://www.feistyduck.com/library/openssl-cookbook/online/ch-testing-with-openssl.html)
+- [Secure Socket Layer/Transport Layer Security on Wikipedia](https://en.wikipedia.org/wiki/Secure_Socket_Layer)
+- [OpenSSL Cookbook - Testing with OpenSSL](https://www.feistyduck.com/library/openssl-cookbook/online/ch-testing-with-openssl.html)
 
 ## Write-up
 
@@ -53,4 +50,5 @@ What `ign_eof` does is it prevents the server from closing down the connection w
 
 Using the correct command and password we get the next password.
 
-#### Level 16 password: `cluFn7wTiGryunymYOu4RcffSxQluehd`
+> **Level 16 password:** `cluFn7wTiGryunymYOu4RcffSxQluehd`
+{: .prompt-tip }

--- a/_posts/2016-05-31-writeup-overthewire-bandit-level16.md
+++ b/_posts/2016-05-31-writeup-overthewire-bandit-level16.md
@@ -16,17 +16,13 @@ ctf_category: Wargame
 description: "Bandit Level 16 → 17: port scanning with nmap to find the SSL listener and get an SSH key"
 ---
 
-#### Level Goal:
+> **Level goal:** The credentials for the next level can be retrieved by submitting the password of the current level to a port on localhost in the range 31000 to 32000. First find out which of these ports have a server listening on them. Then find out which of those speak SSL and which don’t. There is only 1 server that will give the next credentials, the others will simply send back to you whatever you send to it.
 
->The credentials for the next level can be retrieved by submitting the password of the current level to a port on localhost in the range 31000 to 32000. First find out which of these ports have a server listening on them. Then find out which of those speak SSL and which don’t. There is only 1 server that will give the next credentials, the others will simply send back to you whatever you send to it.
+**Commands you may need:** `ssh`, `telnet`, `nc`, `openssl`, `s_client`, `nmap`
 
-#### Commands you may need to solve this level
+**Helpful reading:**
 
->ssh, telnet, nc, openssl, s_client, nmap
-
-#### Helpful Reading Material
-
->[Port scanner on Wikipedia](https://en.wikipedia.org/wiki/Port_scanner)
+- [Port scanner on Wikipedia](https://en.wikipedia.org/wiki/Port_scanner)
 
 ## Write-up
 
@@ -42,4 +38,5 @@ nmap -p 31000-32000 localhost
 
 So there were 5 ports open. I decided to check them all. I tried to connect through `openssl`. `31790` turned out to be the right port. It gave me the private ssh key to the next level on submitting the current one. I saved the key to a file locally and used it to ssh to the next level and got the password there just like in [Level 13](../level13/)
 
-#### Level 17 password: `xLYVMN9WE5zQ5vHacb0sZEVqbrp7nBTn`
+> **Level 17 password:** `xLYVMN9WE5zQ5vHacb0sZEVqbrp7nBTn`
+{: .prompt-tip }

--- a/_posts/2016-05-31-writeup-overthewire-bandit-level17.md
+++ b/_posts/2016-05-31-writeup-overthewire-bandit-level17.md
@@ -16,19 +16,14 @@ ctf_category: Wargame
 description: "Bandit Level 17 → 18: using diff to find the one changed line between two password files"
 ---
 
-#### Level Goal:
+> **Level goal:** There are 2 files in the homedirectory: passwords.old and passwords.new. The password for the next level is in passwords.new and is the only line that has been changed between passwords.old and passwords.new
 
->There are 2 files in the homedirectory: passwords.old and passwords.new. The password for the next level is in passwords.new and is the only line that has been changed between passwords.old and passwords.new
+> NOTE: if you have solved this level and see ‘Byebye!’ when trying to log into bandit18, this is related to the next level, bandit19
+{: .prompt-warning }
 
-**NOTE: if you have solved this level and see ‘Byebye!’ when trying to log into bandit18, this is related to the next level, bandit19**
+**Commands you may need:** `cat`, `grep`, `ls`, `diff`
 
-#### Commands you may need to solve this level
-
->cat, grep, ls, diff
-
-#### Helpful Reading Material
-
->None
+**Helpful reading:** None
 
 ## Write-up
 
@@ -42,4 +37,5 @@ bandit17@melinda:~$ diff passwords.old passwords.new
 
 The output from `password.new` file gives the password.
 
-#### Level 18 password: `kfBf3eYk5BPBRzwjqutbbfE887SVc5Yd`
+> **Level 18 password:** `kfBf3eYk5BPBRzwjqutbbfE887SVc5Yd`
+{: .prompt-tip }

--- a/_posts/2016-06-02-writeup-overthewire-bandit-level18.md
+++ b/_posts/2016-06-02-writeup-overthewire-bandit-level18.md
@@ -16,17 +16,11 @@ ctf_category: Wargame
 description: "Bandit Level 18 → 19: bypassing .bashrc logout by running a command directly over SSH"
 ---
 
-#### Level Goal:
+> **Level goal:** The password for the next level is stored in a file **readme** in the homedirectory. Unfortunately, someone has modified **.bashrc** to log you out when you log in with SSH.
 
->The password for the next level is stored in a file **readme** in the homedirectory. Unfortunately, someone has modified **.bashrc** to log you out when you log in with SSH.
+**Commands you may need:** `ssh`, `ls`, `cat`
 
-#### Commands you may need to solve this level
-
->ssh, ls, cat
-
-#### Helpful Reading Material
-
->None
+**Helpful reading:** None
 
 ## Write-up
 
@@ -54,4 +48,5 @@ There is another way to do it. The `-T` flag. `-T` flag disables pseudo-terminal
 ssh -T bandit18@bandit.labs.overthewire.org
 ~~~
 
-#### Level 19 password: `IueksS7Ubh8G3DCwVzrTd8rAVOwq3M5x`
+> **Level 19 password:** `IueksS7Ubh8G3DCwVzrTd8rAVOwq3M5x`
+{: .prompt-tip }

--- a/_posts/2016-06-02-writeup-overthewire-bandit-level19.md
+++ b/_posts/2016-06-02-writeup-overthewire-bandit-level19.md
@@ -16,17 +16,13 @@ ctf_category: Wargame
 description: "Bandit Level 19 → 20: using a setuid binary to read a file owned by another user"
 ---
 
-#### Level Goal:
+> **Level goal:** To gain access to the next level, you should use the setuid binary in the homedirectory. Execute it without arguments to find out how to use it. The password for this level can be found in the usual place (/etc/bandit_pass), after you have used to setuid binary.
 
->To gain access to the next level, you should use the setuid binary in the homedirectory. Execute it without arguments to find out how to use it. The password for this level can be found in the usual place (/etc/bandit_pass), after you have used to setuid binary.
+**Commands you may need:** None
 
-#### Commands you may need to solve this level
+**Helpful reading:**
 
->None
-
-#### Helpful Reading Material
-
->[setuid on Wikipedia](https://en.wikipedia.org/wiki/Setuid)
+- [setuid on Wikipedia](https://en.wikipedia.org/wiki/Setuid)
 
 ## Write-up
 
@@ -40,4 +36,5 @@ I used this to get the password to next level.
 
 ![Bad Permissions](/assets/images/OverTheWire/Bandit/bad_permission.png)
 
-#### Level 20 password: `GbKksEFF4yrVs6il55v6gwY5aVje5f0j`
+> **Level 20 password:** `GbKksEFF4yrVs6il55v6gwY5aVje5f0j`
+{: .prompt-tip }

--- a/_posts/2016-06-15-different-kinds-of-executables.md
+++ b/_posts/2016-06-15-different-kinds-of-executables.md
@@ -23,71 +23,75 @@ ELF 32-bit LSB executable, Intel 80386, version 1 (SYSV), dynamically linked (us
 
 Lets go through each word one by one.
 
-### ELF
+## ELF
 
 `ELF`(Executable and Linkable Format) is a file format for executables, object code, shared libraries, and core dumps. It is the standard file format for Unix and Unix-like(e.g. Linux) systems. You will mostly encounter this kind of files on your Linux machines.
 
-##### Other:
+### Other
 
 `Mach-O`(Mach object) - For NeXTSTEP, OS X, and iOS
 
 `PE`(Portable Executable) - For Windows Operating System
 
-### 32-bit
+## 32-bit
 
 `32-bit` Computer Architecture system is the one using `x86`, `MIPS32` assembly instruction set.
 
-##### Other:
+### Other
 
 `64-bit` systems use the `x86-64` assembly instruction set.
 
-**Note that this does not tell you the about the system you are working on but about the way the instructions have been structured and written into the binary(So for the same program, 32-bit and 64-bit will have different assembly instructions but the executable would behave the same way).**
+> Note that this does not tell you the about the system you are working on but about the way the instructions have been structured and written into the binary(So for the same program, 32-bit and 64-bit will have different assembly instructions but the executable would behave the same way).
+{: .prompt-info }
 
-**There are other instruction sets as well like `MIPS32`, `MIPS64`, `ARM`, `PowerPC` which you might encounter but in my experience `x86` and `x86-64` are the most commonly used.**
+> There are other instruction sets as well like `MIPS32`, `MIPS64`, `ARM`, `PowerPC` which you might encounter but in my experience `x86` and `x86-64` are the most commonly used.
+{: .prompt-info }
 
-### LSB
+## LSB
 
 The Linux Standard Base (LSB) is a joint project by several Linux distributions under the organizational structure of the Linux Foundation to standardize the software system structure. This basically means that across different Linux based Operating Systems(Ubuntu, Fedora etc.), common rules would be used for compiling information into the binary(e.g. using some standard libraries for specific task, standardising the layout of the file system hierarchy etc.).
 
-### Intel 80386
+## Intel 80386
 
 `Intel 80386` is a 32-bit microprocessor by Intel. This means that the executable can be run on Intel's 80386 microprocessor or anything compatible with it. The latest 64-bit microprocessors are all backward compatible with the 32-bit ones.
 
-### SYSV
+## SYSV
 
 `SYSV` is short for System Five. It is one of the first commercial versions of the Unix operating system developeed by AT&T. The other major version of Unix is `BSD`(Berkely Software Distribution)
 
-##### Other
+### Other
 
 `GNU/Linux` - It is very obvious that this refers to the Linux operating system.
 
-### Dynamically linked (uses shared libs)
+## Dynamically linked (uses shared libs)
 
 In `Dynamic linking` the names of the external libraries (shared libraries) are placed in the final executable file while the actual linking takes place at run time when both executable file and libraries are placed in the memory. Thus we don't have to keep the standard libraries inside the binary(You import these in your program). This helps keep the file size low and also lets several programs use a single copy of an executable module.
 
-##### Other
+### Other
 
 In `Static linking` all library modules used in the program are copied into the final executable image. This is performed by the linker and it is done as the last step of the compilation process. This naturally increases the file size a lot.
 
-**Note that programs that use statically-linked libraries are usually faster than those that use shared libraries. Also in statically-linked programs, all code is contained in a single executable module. Therefore, they never run into compatibility issues.**
+> Note that programs that use statically-linked libraries are usually faster than those that use shared libraries. Also in statically-linked programs, all code is contained in a single executable module. Therefore, they never run into compatibility issues.
+{: .prompt-info }
 
-### interpreter /lib/ld-linux.so.2
+## interpreter /lib/ld-linux.so.2
 
 This the ELF interpreter. It is responsible for dynamic linking.
 
-### for GNU/Linux 2.6.32
+## for GNU/Linux 2.6.32
 
 `2.6.32` represents the version of the Linux kernal the C library linked with the program targets. I'm not exactly sure how kernals work though so I can't elaborate much on this.
 
-### not stripped
+## not stripped
 
 `Non stripped` binaries contain debugging information. This information is a representation of the relationship between the executable program and the original source code. It includes things like Global and Static variable names and function names.<br>
 `Stripped` binaries on the other hand lack this debugging information.
 
-**All these things are a must know for a Reverse Engineer. I hope this blog increased you knowledge in this genre. :) In case of any doubts comment below.**
+All these things are a must know for a Reverse Engineer. I hope this blog increased you knowledge in this genre. :) In case of any doubts comment below.
 
-**Cheers!**
+Cheers!
 
-**If you are an Infosec person, don't forget to checkout my [CTF Write-ups](/writeups/)**
+> If you are an Infosec person, don't forget to checkout my [CTF Write-ups](/writeups/)
+{: .prompt-tip }
 
 [See other Blog posts](/blog/)

--- a/_posts/2017-08-05-writeup-runesec_evecodesbetter.md
+++ b/_posts/2017-08-05-writeup-runesec_evecodesbetter.md
@@ -16,15 +16,12 @@ description: "Cracking a Vigenère cipher and XOR-encoded PNG to reveal the hidd
 ctf_category: Crypto
 ---
 
-#### Points: 400
+> **Challenge:** There is a website running at `http://challenges.runesec.com:62856` (no longer available). Try to see if you can become an administrator.
 
-#### Description:
+> **Hint:** Everyone knows that mode is bad because we can see the penguin!
+{: .prompt-tip }
 
-> There is a website running at `http://challenges.runesec.com:62856` (no longer available). Try to see if you can become an administrator.
-
-##### Hints:
-
-> Everyone knows that mode is bad because we can see the penguin!
+## Write-up
 
 I don't do crypto challenges usually but since this was an easy CTF, I decided to try it out.
 
@@ -70,7 +67,8 @@ Penguin...What kind of hint is this. And then it struck me. The same day we had 
 
 So what happens in ECB is that you independently encrypt blocks of the original text with the keys. Now this causes two blocks which are the same to have the same encrypted output. Thus there is confusion but no diffusion. (Ask in the comments if you don't know what this means.)
 
-**Note:** ECB is a general technique used by block ciphers and is by no means specific to only AES.
+> **Note:** ECB is a general technique used by block ciphers and is by no means specific to only AES.
+{: .prompt-info }
 
 Now we need to determine what the size of each block is. I noticed that `5e72ac7a72f2100c` repeated twice in the cookie. As expected there were to two equal strings `username` at a similar offset as the encrypted block. So I figured it might be a 64-bit encryption.
 
@@ -132,4 +130,5 @@ Thus `is__admin` now equals `__True__`, and we're in. Hacked!
 
 ![Penguin](/assets/images/evecodesbetter/ecb.png)
 
-**Go through other [writeups](/writeups/) for more such fun challenges.**
+> Go through other [writeups](/writeups/) for more such fun challenges.
+{: .prompt-tip }

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -415,10 +415,17 @@ $tn-max: 1140px;
 /* ---------- Post reading measure ---------- */
 /* The default article column runs ~100 chars/line, which is too wide for
    comfortable prose. Constrain the article and its footer (Further Reading /
-   comments) to a readable measure, left-aligned; the TOC stays on the right. */
+   comments) to a readable measure and centre it, so on wide screens the column
+   sits balanced rather than hugging the far-left gutter (the TOC stays on the
+   right). The article (.post-page) centres inside <main>; the tail sections
+   (Further Reading, comments, footer) are direct children of #tail-wrapper, an
+   identical-width column, so centring those children keeps them aligned with
+   the article body. `margin: auto` is a no-op while the column already fills a
+   narrow viewport, so no breakpoint gating is needed. */
 .post-page,
-#main-wrapper:has(.post-page) #tail-wrapper {
-  max-width: 46rem;
+#main-wrapper:has(.post-page) #tail-wrapper > * {
+  max-width: 40rem;
+  margin-inline: auto;
 }
 
 /* Accent tag pills at the foot of the article */


### PR DESCRIPTION
## Post reading polish (af2.41)

Narrows the article reading measure and makes heading hierarchy + callouts idiomatic on `layout: post` pages.

### What changed
- **Reading measure:** post body + footer `max-width` 46rem → 40rem (~80 chars/line, comfortable for prose).
- **OverTheWire Bandit write-ups (×20):** the Level Goal heading + quote become one labelled blockquote; **Commands** and **Helpful Reading** become bold-labelled text (inline code / bullet lists) instead of blockquotes — fixing multi-link lists that previously collapsed onto a single run-on line; each next-level password moves into a `.prompt-tip` callout; the level 15/17 goal notes become `.prompt-warning` callouts. "Write-up" is now the only content heading, so the table of contents no longer lists passwords or metadata.
- **"Knowing your Binary!":** section headings shift h3 → h2 and subsections h5 → h3; the informational bold paragraphs become `.prompt-info` callouts; the write-ups call-to-action becomes a `.prompt-tip`; the sign-off lines are unbolded.
- **RuneSec CTF write-up:** the Description/Hints headings become a labelled Challenge blockquote + a `.prompt-tip` Hint; the redundant `Points: 400` heading is dropped (the point value already renders in the post meta as "🏆 400 pts"); the in-prose Note becomes a `.prompt-info` and the closing CTA a `.prompt-tip`; "Write-up" is now the only content heading.

### Verification
- Production Jekyll build succeeds; compiled HTML shows the intended `.prompt-*` callouts and a clean h1→h2→h3 hierarchy.
- Reviewed in light + dark themes on desktop (1280px) and mobile (390px).

---

### Bandit Level 15

**Light — before / after** (note the run-on Helpful-Reading links and password-as-heading in "before")

| Before | After |
| --- | --- |
| ![before](https://github.com/CodeMaxx/CodeMaxx.github.io/releases/download/pr-assets/af241-bandit15-before-light.png) | ![after](https://github.com/CodeMaxx/CodeMaxx.github.io/releases/download/pr-assets/af241-bandit15-after-light.png) |

**Dark — before / after**

| Before | After |
| --- | --- |
| ![before](https://github.com/CodeMaxx/CodeMaxx.github.io/releases/download/pr-assets/af241-bandit15-before-dark.png) | ![after](https://github.com/CodeMaxx/CodeMaxx.github.io/releases/download/pr-assets/af241-bandit15-after-dark.png) |

**After — mobile (390px)**

![mobile](https://github.com/CodeMaxx/CodeMaxx.github.io/releases/download/pr-assets/af241-bandit15-after-mobile.png)

---

### Knowing your Binary!

**Light — before / after** (bold pseudo-callouts → tinted callouts; wider → narrower measure)

| Before | After |
| --- | --- |
| ![before](https://github.com/CodeMaxx/CodeMaxx.github.io/releases/download/pr-assets/af241-exec-before-light.png) | ![after](https://github.com/CodeMaxx/CodeMaxx.github.io/releases/download/pr-assets/af241-exec-after-light.png) |

**Dark — before / after**

| Before | After |
| --- | --- |
| ![before](https://github.com/CodeMaxx/CodeMaxx.github.io/releases/download/pr-assets/af241-exec-before-dark.png) | ![after](https://github.com/CodeMaxx/CodeMaxx.github.io/releases/download/pr-assets/af241-exec-after-dark.png) |

**After — mobile (390px)**

![mobile](https://github.com/CodeMaxx/CodeMaxx.github.io/releases/download/pr-assets/af241-exec-after-mobile.png)

---

### RuneSec CTF 2017 — EveCodesBetter

**Light — before / after** (Points/Description/Hints headings → labelled Challenge quote + Hint callout; "Write-up" becomes the only heading)

| Before | After |
| --- | --- |
| ![before](https://github.com/CodeMaxx/CodeMaxx.github.io/releases/download/pr-assets/af241-runesec-before-light.png) | ![after](https://github.com/CodeMaxx/CodeMaxx.github.io/releases/download/pr-assets/af241-runesec-after-light.png) |

**Dark — before / after**

| Before | After |
| --- | --- |
| ![before](https://github.com/CodeMaxx/CodeMaxx.github.io/releases/download/pr-assets/af241-runesec-before-dark.png) | ![after](https://github.com/CodeMaxx/CodeMaxx.github.io/releases/download/pr-assets/af241-runesec-after-dark.png) |
