### PR TITLE
Mark external posts with an External meta marker

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -147,13 +147,19 @@ refactor: true
                   {% include datetime.html date=post.date lang=lang %}
                 </span>
 
-                <!-- reading time (skip external redirects, which have no local content) -->
-                {% unless post.redirect_to %}
+                <!-- reading time, or an explicit External marker for
+                     redirect_to posts (which have no local content) -->
+                {% if post.redirect_to %}
+                  <span class="meta-item meta-external">
+                    <i class="fas fa-arrow-up-right-from-square fa-fw me-1"></i>
+                    <span>External</span>
+                  </span>
+                {% else %}
                   <span class="meta-item">
                     <i class="far fa-clock fa-fw me-1"></i>
                     {% include read-time.html content=post.content prompt=true lang=lang %}
                   </span>
-                {% endunless %}
+                {% endif %}
 
                 <!-- points (CTF write-ups) -->
                 {% if post.points %}

--- a/_layouts/landing.html
+++ b/_layouts/landing.html
@@ -111,10 +111,13 @@ refactor: true
 
             <div class="feature-meta">
               <span><i class="far fa-calendar fa-fw"></i>{% include datetime.html date=post.date lang=lang %}</span>
-              {% unless post.redirect_to %}
+              {% if post.redirect_to %}
+                <span class="feature-meta-sep">&middot;</span>
+                <span class="feature-meta-external"><i class="fas fa-arrow-up-right-from-square fa-fw"></i> External</span>
+              {% else %}
                 <span class="feature-meta-sep">&middot;</span>
                 <span>{% include read-time.html content=post.content prompt=true lang=lang %}</span>
-              {% endunless %}
+              {% endif %}
               {% if post.points %}
                 <span class="feature-meta-sep">&middot;</span>
                 <span><i class="fas fa-trophy fa-fw"></i>{{ post.points }} pts</span>

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -28,14 +28,19 @@
   border: 0;
 }
 
-/* External-link indicator on post cards whose target leaves the site
-   (posts with `redirect_to`). Kept subtle: muted colour, smaller than the
-   title, and nudged up slightly so it reads as a superscript-style badge. */
+/* External-link indicator on post cards / feature titles whose target leaves
+   the site (posts with `redirect_to`). Accent-coloured so the leaves-site cue
+   reads clearly, and nudged up slightly like a superscript badge. */
 .card-title .external-link-icon {
   font-size: 0.6em;
-  color: var(--text-muted-color);
+  color: var(--accent-1);
   vertical-align: 0.35em;
-  opacity: 0.85;
+}
+/* Explicit "External" marker that fills the read-time slot on redirect_to
+   posts (which have no local content, hence no reading time). */
+.meta-item.meta-external,
+.feature-meta-external {
+  color: var(--accent-1);
 }
 
 /* ============================================================
@@ -1231,7 +1236,7 @@ div[class^='language-'] .code-header {
   }
   .feature-title .external-link-icon {
     font-size: 0.6em;
-    color: var(--text-muted-color);
+    color: var(--accent-1);
     vertical-align: 0.35em;
   }
   .feature-meta {


### PR DESCRIPTION
External (`redirect_to`) posts link out to another site, so they have no local content and therefore no reading time. That left their meta row looking half-populated next to their neighbours — just a date, where every other post shows "· N min read".

They now show an explicit accent-coloured **External** marker in that slot, and the external-link title arrow is accent-coloured so the "leaves this site" cue reads clearly. Applied on both the landing recent-posts list and the listing cards.

**Landing — recent posts** (see "HackInOut 4.0 Winners")

| Before | After |
| --- | --- |
| ![landing before](https://github.com/CodeMaxx/CodeMaxx.github.io/releases/download/pr-assets/af2-44-landing-before.png) | ![landing after](https://github.com/CodeMaxx/CodeMaxx.github.io/releases/download/pr-assets/af2-44-landing.png) |

**Blog listing** (see "HackInOut 4.0 Winners" and "Awesome Terminal Commands")

| Before | After |
| --- | --- |
| ![blog before](https://github.com/CodeMaxx/CodeMaxx.github.io/releases/download/pr-assets/af2-44-blog-before.png) | ![blog after](https://github.com/CodeMaxx/CodeMaxx.github.io/releases/download/pr-assets/af2-44-blog.png) |

## Testing

- `JEKYLL_ENV=production bundle exec jekyll build` — clean.
- Verified the landing recent-posts and `/blog/` (external posts "HackInOut 4.0 Winners" and "Awesome Terminal Commands") in both light and dark themes.
