### PR TITLE
Match imageless listing cards to the image cards' cover height

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -693,6 +693,13 @@ div[class^='language-'] .code-header {
     min-height: 100%;
     border-radius: 0 12px 12px 0;
   }
+
+  /* Imageless posts use the placeholder (no intrinsic height); give it the
+     cover ratio so its card matches the image cards instead of collapsing. */
+  #post-list .post-preview .card-media:has(.card-media-placeholder) {
+    height: auto;
+    aspect-ratio: 15 / 8;
+  }
 }
 
 /* Listing card meta row: let the date / read-time / points / category groups


### PR DESCRIPTION
## Problem

On the **blog / write-ups / projects** listing pages, each post''s cover image drives its card height by design. Posts with **no image** fall back to the accent feather placeholder, which has no intrinsic height — so those cards collapsed to their **text height (~208px)** and read as noticeably **shorter than the surrounding image cards (~238-251px)**.

Reported on the live site: the oldest post, *"Checking out Stuff"* (imageless), looked short next to every image card around it.

## Fix

On desktop (`>=768px`) give the imageless placeholder media a **15:8 cover ratio** (matching the cover art) so an imageless card fills to the same height as the rest. **Image cards are unchanged** — their deliberate per-post heights are preserved.

CSS-only, 7 lines in `assets/css/style.scss`.

## Before / After

Live `/blog/` vs. this branch (local production build):

| Before (live) | After (this branch) |
|---|---|
| ![before](https://github.com/CodeMaxx/CodeMaxx.github.io/releases/download/pr-assets/cardheight-before.png) | ![after](https://github.com/CodeMaxx/CodeMaxx.github.io/releases/download/pr-assets/cardheight-after-v2.png) |

**Before:** the imageless *"Checking out Stuff"* card is shorter than its neighbours. **After:** it fills a 15:8 cover and matches; image cards untouched.

## Verification

Local production build, images loaded, `/blog/` @1920:

| Card type | Height |
|---|---|
| Image cards (per-post cover) | 237-251px (unchanged) |
| Placeholder cards (*Awesome Terminal Commands*, *Checking out Stuff*) | 208px -> **238px** |

Both imageless cards now sit within the image-card band. No horizontal overflow; mobile 16:9 stacked cover unchanged.
