### PR TITLE
Polish legacy posts: idiomatic headings and Chirpy callouts

### DIFF
--- a/_posts/2016-05-16-writeup-infosec_institute_n00b_ctf-level1.md
+++ b/_posts/2016-05-16-writeup-infosec_institute_n00b_ctf-level1.md
@@ -16,12 +16,6 @@ points: 10
 ctf_category: Web
 ---
 
-#### Points: 10
-
-#### Description:
-
-
-
 ## Write-up
 
 "May the source be with you!". Yoda hints us to look at the source code of the webpage. Right click on the webpage and click `View Page Source`. At the top of the source code we see:
@@ -32,4 +26,4 @@ ctf_category: Web
 
 This gives away the flag!
 
-#### Flag: `infosec_flagis_welcome`
+**Flag:** `infosec_flagis_welcome`

--- a/_posts/2016-05-16-writeup-infosec_institute_n00b_ctf-level2.md
+++ b/_posts/2016-05-16-writeup-infosec_institute_n00b_ctf-level2.md
@@ -16,10 +16,6 @@ points: 20
 ctf_category: Web
 ---
 
-#### Points: 20
-
-#### Description:
-
 ## Write-up
 
 Seeing that the Image was broken I went to the source code to check why. There could have been two reasons - the file is not present at the path specified for the image or the file is not a proper image.
@@ -54,4 +50,4 @@ echo 'aW5mb3NlY19mbGFnaXNfd2VhcmVqdXN0c3RhcnRpbmc=' | base64 --decode
 
 Voila! There's the flag.
 
-#### Flag: `infosec_flagis_wearejuststarting`
+**Flag:** `infosec_flagis_wearejuststarting`

--- a/_posts/2016-05-16-writeup-infosec_institute_n00b_ctf-level3.md
+++ b/_posts/2016-05-16-writeup-infosec_institute_n00b_ctf-level3.md
@@ -16,10 +16,6 @@ points: 30
 ctf_category: Web
 ---
 
-#### Points: 30
-
-#### Description:
-
 ## Write-up
 
 I saw two suspicious things on the page - a QR code and a 90% complete progress bar. I went to the source code and saw the progress bar was hardcoded to remain at 90% and hence it is just a distraction.
@@ -35,4 +31,4 @@ I got `INFOSECFLAGISMORSING`.
 
 This gives away the flag.
 
-#### Flag: `infosec_flagis_morsing`
+**Flag:** `infosec_flagis_morsing`

--- a/_posts/2016-05-31-writeup-overthewire-bandit-level06.md
+++ b/_posts/2016-05-31-writeup-overthewire-bandit-level06.md
@@ -41,7 +41,8 @@ That file had the password for Level 7.
 bandit6@melinda:/$ cat ./var/lib/dpkg/info/bandit7.password
 ~~~~
 
-**Edit:** Yay! Got a nicer one line method to do this.
+> **Edit:** Yay! Got a nicer one line method to do this.
+{: .prompt-info }
 
 ~~~bash
 cat `find . -size 33c -group bandit6 -user bandit7 2>/dev/null`

--- a/_posts/2016-05-31-writeup-overthewire-bandit-level08.md
+++ b/_posts/2016-05-31-writeup-overthewire-bandit-level08.md
@@ -32,7 +32,8 @@ I really didn't use a proper method to solve this one. I used `sort data.txt` to
 
 Hence I got the password.
 
-**Edit:** Found a better method for this. The `uniq` command! When the data is sorted the `-u` flag can be used to print only the unique lines.
+> **Edit:** Found a better method for this. The `uniq` command! When the data is sorted the `-u` flag can be used to print only the unique lines.
+{: .prompt-info }
 
 ~~~bash
 sort data.txt | uniq -u

--- a/_posts/2016-05-31-writeup-overthewire-bandit-level13.md
+++ b/_posts/2016-05-31-writeup-overthewire-bandit-level13.md
@@ -33,7 +33,8 @@ It provides us with the private ssh key for the next level. This is how a privat
 I copied the key and created an identical file on my machine.
 Then I used it to login to Level 14.
 
-**Note that you need to change permission of the file to `600`. For this use `chmod`.**
+> Note that you need to change permission of the file to `600`. For this use `chmod`.
+{: .prompt-warning }
 
 ~~~bash
 CodeMaxx:~$ chmod 600 sshkey.private

--- a/_posts/2016-05-31-writeup-overthewire-bandit-level15.md
+++ b/_posts/2016-05-31-writeup-overthewire-bandit-level15.md
@@ -46,7 +46,8 @@ What `ign_eof` does is it prevents the server from closing down the connection w
 
 `connect host:port` specifies the host and optional port to connect to. If not specified then an attempt is made to connect to the local host on port 4433.
 
-**Note that `-ign_eof` and `-connect host:port` flags are under `man s_client` and not `man openssl`.**
+> Note that `-ign_eof` and `-connect host:port` flags are under `man s_client` and not `man openssl`.
+{: .prompt-info }
 
 Using the correct command and password we get the next password.
 

--- a/_posts/2016-06-07-importance-of-quotes-in-terminal.md
+++ b/_posts/2016-06-07-importance-of-quotes-in-terminal.md
@@ -17,7 +17,7 @@ I was tinkering with the `echo` command when I came across the difference betwee
 
 This can best be explained using some examples.
 
-**NO QUOTES**
+## No quotes
 
 ```bash
 echo test ~/*.txt {code,maxx} $(echo foo) $((2+2)) $USER `echo bar` \$100
@@ -40,7 +40,7 @@ So we see some of the commands got expanded:
 
 Ok so that was some nice stuff. Now lets move on to the quotes.
 
-**DOUBLE QUOTES**
+## Double quotes
 
 ```bash
 echo "test ~/*.txt {code,maxx} $(echo foo) $((2+2)) $USER `echo bar` \$100"
@@ -55,7 +55,7 @@ Now we see some expansions were restricted. With double qoutes all the special c
 - Backtick(`)
 - Backslash(`\`)
 
-**SINGLE QUOTES**
+## Single quotes
 
 ```bash
 echo 'test ~/*.txt {code,maxx} $(echo foo) $((2+2)) $USER `echo bar` \$100'
@@ -66,4 +66,7 @@ test ~/*.txt {code,maxx} $(echo foo) $((2+2)) $USER `echo bar` \$100
 
 We see that using single quotes prevents all expansions. ALL special characters lose thier meaning! This is why it is recommended to use single quotes while writing aliases so that we can put the exact input in it and we don't have to worry about it being modified while substitution.
 
-**Hope this helped :) In case you have any doubts comment below. If you are an Infosec person, don't forget to checkout my [Write-ups](/writeups/)**
+Hope this helped :) In case you have any doubts comment below.
+
+> If you are an Infosec person, don't forget to checkout my [Write-ups](/writeups/).
+{: .prompt-tip }

--- a/_posts/2016-06-07-writeup-backdoorctf16-0intro16.md
+++ b/_posts/2016-06-07-writeup-backdoorctf16-0intro16.md
@@ -16,13 +16,10 @@ ctf_category: Misc
 description: "BackdoorCTF 2016 intro16: collecting flag fragments from IRC and Twitter"
 ---
 
-**BackdoorCTF is the annual flagship CTF competition conducted by SDSLabs and InfoSecIITR.**
+> BackdoorCTF is the annual flagship CTF competition conducted by SDSLabs and InfoSecIITR.
+{: .prompt-info }
 
-#### Points: 10
-
-#### Description:
-
->Get the first part of the flag from IRC freenode (#backdoorctf) and the second part from twitter(@BackdoorCTF)
+> **Challenge:** Get the first part of the flag from IRC freenode (#backdoorctf) and the second part from twitter(@BackdoorCTF)
 
 ## Write-up
 

--- a/_posts/2016-06-07-writeup-backdoorctf16-1jigsaw.md
+++ b/_posts/2016-06-07-writeup-backdoorctf16-1jigsaw.md
@@ -16,13 +16,10 @@ ctf_category: Misc
 description: "BackdoorCTF 2016 jigsaw: manually reassembling 64 image pieces to decode 16 characters"
 ---
 
-**BackdoorCTF is the annual flagship CTF competition conducted by SDSLabs and InfoSecIITR.**
+> BackdoorCTF is the annual flagship CTF competition conducted by SDSLabs and InfoSecIITR.
+{: .prompt-info }
 
-#### Points: 150
-
-#### Description:
-
-> cr4wl3r was always found solving jigsaw puzzle. Let us know why he solves so many jigsaws by solving the same. Get the puzzle pieces ~~[here](http://hack.bckdr.in/JIGSAW/jigsaw.tar.gz)~~ *(CTF server no longer available)*
+> **Challenge:** cr4wl3r was always found solving jigsaw puzzle. Let us know why he solves so many jigsaws by solving the same. Get the puzzle pieces ~~[here](http://hack.bckdr.in/JIGSAW/jigsaw.tar.gz)~~ *(CTF server no longer available)*
 
 ## Write-up
 
@@ -48,4 +45,5 @@ I didn't try the the solver yet. But it will probably give you most of the lette
 
 **Next:** So now we got a list of 16 letters. I looked at them for sometime trying to unjumble them. In about 5 minutes I got `LOVEBEINGPUZZLED`.
 
-**Go through other [writeups](/writeups/) for more such fun challenges.**
+> Go through other [writeups](/writeups/) for more such fun challenges.
+{: .prompt-tip }

--- a/_posts/2016-06-07-writeup-backdoorctf16-2isolve.md
+++ b/_posts/2016-06-07-writeup-backdoorctf16-2isolve.md
@@ -16,13 +16,10 @@ ctf_category: Exploit
 description: "BackdoorCTF 2016 isolve: auto-generating regex-matching strings with exrex under a time limit"
 ---
 
-**BackdoorCTF is the annual flagship CTF competition conducted by SDSLabs and InfoSecIITR.**
+> BackdoorCTF is the annual flagship CTF competition conducted by SDSLabs and InfoSecIITR.
+{: .prompt-info }
 
-#### Points: 200
-
-#### Description:
-
->~~nc hack.bckdr.in 7070~~ *(CTF server no longer available)*
+> **Challenge:** ~~nc hack.bckdr.in 7070~~ *(CTF server no longer available)*
 
 ## Write-up
 
@@ -66,4 +63,5 @@ This gave me this :) :
 followed by the flag of the form<br>
 `flag{...}`
 
-**Go through other [writeups](/writeups/) for more such fun challenges.**
+> Go through other [writeups](/writeups/) for more such fun challenges.
+{: .prompt-tip }

--- a/_posts/2016-06-07-writeup-backdoorctf16-3imagelover.md
+++ b/_posts/2016-06-07-writeup-backdoorctf16-3imagelover.md
@@ -16,17 +16,15 @@ ctf_category: Web
 description: "BackdoorCTF 2016 imagelover: web exploitation via malicious image upload"
 ---
 
-**BackdoorCTF is the annual flagship CTF competition conducted by SDSLabs and InfoSecIITR.**
+> BackdoorCTF is the annual flagship CTF competition conducted by SDSLabs and InfoSecIITR.
+{: .prompt-info }
 
-#### Points: 70
-
-#### Description:
-
->Find imagelover ~~[here](http://hack.bckdr.in:6969/)~~ *(CTF server no longer available)*
+> **Challenge:** Find imagelover ~~[here](http://hack.bckdr.in:6969/)~~ *(CTF server no longer available)*
 
 ## Write-up
 
-**The challenge was updated. Scroll down to see the updates solution**
+> The challenge was updated. Scroll down to see the updated solution.
+{: .prompt-info }
 
 When I went to the specified website it said:
 
@@ -73,4 +71,5 @@ Basically I hosted my VPS with the script above and entered the URL in place of 
 
 And as expeced as soon as I submitted my URL I got a GET request with the flag in the cookie.
 
-**Go through other [writeups](/writeups/) for more such fun challenges.**
+> Go through other [writeups](/writeups/) for more such fun challenges.
+{: .prompt-tip }

--- a/_posts/2016-06-08-writeup-backdoorctf16-4busybee.md
+++ b/_posts/2016-06-08-writeup-backdoorctf16-4busybee.md
@@ -16,13 +16,10 @@ ctf_category: Forensics
 description: "BackdoorCTF 2016 buzybee: forensics challenge extracting a flag virus from infected files"
 ---
 
-**BackdoorCTF is the annual flagship CTF competition conducted by SDSLabs and InfoSecIITR.**
+> BackdoorCTF is the annual flagship CTF competition conducted by SDSLabs and InfoSecIITR.
+{: .prompt-info }
 
-#### Points: 150
-
-#### Description:
-
->A deadly virus is killing bees in Busybee's village Busybox, India. Unfortuantely, you have to go to the village to fight the infection. Get the flag virus out of the infected files.
+> **Challenge:** A deadly virus is killing bees in Busybee's village Busybox, India. Unfortuantely, you have to go to the village to fight the infection. Get the flag virus out of the infected files.
 Village address: ~~[http://hack.bckdr.in/BUSYBEE/infected.tar](http://hack.bckdr.in/BUSYBEE/infected.tar)~~ *(CTF server no longer available)*
 
 ## Write-up
@@ -37,4 +34,5 @@ One of them indeed had the flag.
 
 So that was too easy for a 150 points question so I asked around about the expeced solution. Turns out this was a Docker dump. It had to be mounted in Docker and then searched for abnomalities. I have not tried that out yet(I'll have to set up Docker on my machine. I'm feeling too lazy right now.). I'll do it soon though and update this writeup accordingly.
 
-**Go through other [writeups](/writeups/) for more such fun challenges.**
+> Go through other [writeups](/writeups/) for more such fun challenges.
+{: .prompt-tip }

--- a/_posts/2016-06-09-writeup-backdoorctf16-5debug.md
+++ b/_posts/2016-06-09-writeup-backdoorctf16-5debug.md
@@ -16,13 +16,10 @@ ctf_category: Reversing
 description: "BackdoorCTF 2016 debug: reversing a 32-bit binary and hashing the result with SHA256"
 ---
 
-**BackdoorCTF is the annual flagship CTF competition conducted by SDSLabs and InfoSecIITR.**
+> BackdoorCTF is the annual flagship CTF competition conducted by SDSLabs and InfoSecIITR.
+{: .prompt-info }
 
-#### Points: 30
-
-#### Description:
-
->Take sha256 of string obtained.
+> **Challenge:** Take sha256 of string obtained.
 ~~[http://hack.bckdr.in/DEBUG/debug32](http://hack.bckdr.in/DEBUG/debug32)~~ *(CTF server no longer available)*
 
 ## Write-up
@@ -53,4 +50,5 @@ This as expected printed out the flag!
 
 ![Flag Printed](/assets/images/backdoorctf16/debug_flag.png)
 
-**Go through other [writeups](/writeups/) for more such fun challenges.**
+> Go through other [writeups](/writeups/) for more such fun challenges.
+{: .prompt-tip }

--- a/_posts/2016-06-10-writeup-backdoorctf16-6enter-the-matrix.md
+++ b/_posts/2016-06-10-writeup-backdoorctf16-6enter-the-matrix.md
@@ -16,18 +16,16 @@ ctf_category: Pwn
 description: "BackdoorCTF 2016 enter the matrix: binary exploitation to reach the flag on a remote server"
 ---
 
-**BackdoorCTF is the annual flagship CTF competition conducted by SDSLabs and InfoSecIITR.**
+> BackdoorCTF is the annual flagship CTF competition conducted by SDSLabs and InfoSecIITR.
+{: .prompt-info }
 
-#### Points: 350
-
-#### Description:
-
->Can you reach Zion and find the flag? You can download a copy of the Matrix to play with ~~[here](http://hack.bckdr.in/ENTER-THE-MATRIX/matrix)~~ *(CTF server no longer available)*, but the flag can only be found on Zion, through the real Matrix at
+> **Challenge:** Can you reach Zion and find the flag? You can download a copy of the Matrix to play with ~~[here](http://hack.bckdr.in/ENTER-THE-MATRIX/matrix)~~ *(CTF server no longer available)*, but the flag can only be found on Zion, through the real Matrix at
 ~~nc hack.bckdr.in 9004~~ *(server offline)*
 
 ## Write-up
 
-**For this one I went a long way around to finally get the solution. Since this is my first writeup with pwning, I'll be writing about the whole journey around the binary so if you want to just quickly see the solution, [jump here](#the-actual-solution)**
+> For this one I went a long way around to finally get the solution. Since this is my first writeup with pwning, I'll be writing about the whole journey around the binary so if you want to just quickly see the solution, [jump here](#the-actual-solution).
+{: .prompt-tip }
 
 So they gave a 32-bit ELF non-stripped executable. I opened it up in IDA and saw a function named `zion`. According to the description this is where we have to reach to get the flag. This function was making some `_system` call which is what I had to finally exploit. I decided to go into its details later and rather focus on reaching there first.
 

--- a/_posts/2016-07-07-how-to-crack-wifi-password.md
+++ b/_posts/2016-07-07-how-to-crack-wifi-password.md
@@ -37,4 +37,5 @@ It’s tough to say how long it would take to crack a password in this way. For 
 
 P.S. - For Educational purposes only.
 
-**Update:** Here's a nice step-by-step description (with commands) of how to do this -> [Wifi Cracking](https://github.com/brannondorsey/wifi-cracking)
+> **Update:** Here's a nice step-by-step description (with commands) of how to do this -> [Wifi Cracking](https://github.com/brannondorsey/wifi-cracking)
+{: .prompt-tip }

--- a/_posts/2016-11-03-did-i-execute.md
+++ b/_posts/2016-11-03-did-i-execute.md
@@ -25,7 +25,7 @@ What people don't realise is that all of them are meant for completely different
 
 Let me elaborate.
 
-### **Semicolon `;`**
+## Semicolon `;`
 
 Semicolon is `the` legit command separator. Let us see some examples.
 
@@ -39,7 +39,7 @@ OK
 
 Thus `A ; B` implies **Run A and then B**. Very straight-foward. No tricks. Lets move to `&&` and `||`.
 
-### **Double ampersand `&&` and Double pipe `||`**
+## Double ampersand `&&` and Double pipe `||`
 
 `&&` and `||` are **Logical Binary Operators** and as you might have guessed `&&` is Logical AND, `||` is Logical OR.
 
@@ -49,7 +49,8 @@ But where are the boolean values in `echo hello && echo world!` ?
 
 These values are derived from the **Exit status** of the commands!
 
-**Note** that a logical AND checks the second operand only when the first one is `true`. Similarly logical OR checks the second operand only when the first one is `false`.
+> A logical AND checks the second operand only when the first one is `true`. Similarly logical OR checks the second operand only when the first one is `false`.
+{: .prompt-info }
 
 Thus in `A && B`, B executes only when A is a success( exit status 0 ) while in `A || B`, B executes only when A returns an error. Thus both commands may not always execute! Lets see some examples.
 
@@ -82,4 +83,7 @@ $ false && echo success || echo fail
 fail
 ```
 
-**Hope this helped :) In case you have any doubts comment below. If you are an Infosec person, don't forget to checkout my [Write-ups](/writeups/)**
+Hope this helped :) In case you have any doubts comment below.
+
+> If you are an Infosec person, don't forget to checkout my [Write-ups](/writeups/).
+{: .prompt-tip }

--- a/_posts/2017-05-03-printing-emojis-on-terminal.md
+++ b/_posts/2017-05-03-printing-emojis-on-terminal.md
@@ -66,7 +66,7 @@ std::string question = "\xE2\x9D\x93"; // The C++ way
 
 UTF-8 encoding uses at max 4 bytes for representing any character. Just add that `'\0'` as the last charater to prevent disasters while printing. `std::string` handles this automatically.
 
-#### Didn't work?
+### Didn't work?
 
 If this doesn't seem to work for you try adding this line to the beginning of the main function:
 
@@ -74,11 +74,12 @@ If this doesn't seem to work for you try adding this line to the beginning of th
 
 You will also have to `#include<locale.h>`
 
-#### Resources
+## Resources
 
 The Unicode and UTF8 values for some common emojis can be found [here](https://apps.timwhitlock.info/emoji/tables/unicode).
 
-**Bonus:** Get markdown emoji codes [here](https://www.webfx.com/tools/emoji-cheat-sheet/)
+> **Bonus:** Get markdown emoji codes [here](https://www.webfx.com/tools/emoji-cheat-sheet/).
+{: .prompt-tip }
 
 ---
 

--- a/_posts/2017-06-12-writeup-pwnablekr_todders_bottle.md
+++ b/_posts/2017-06-12-writeup-pwnablekr_todders_bottle.md
@@ -16,7 +16,8 @@ description: "Walkthroughs for fd, collision, bof, flag, and passcode challenges
 ctf_category: Pwn
 ---
 
-**[pwnable.kr](https://pwnable.kr) is a wargame site which provides various pwn challenges regarding system exploitation. The main purpose of pwnable.kr is having "fun" while improving one's hacking skills ;)**
+> [pwnable.kr](https://pwnable.kr) is a wargame site which provides various pwn challenges regarding system exploitation. The main purpose of pwnable.kr is having "fun" while improving one's hacking skills ;)
+{: .prompt-info }
 
 Toddler's Bottle is a section of easy-ish challenges. This writeup contains solutions to almost all of the challenges in that section.
 
@@ -41,7 +42,8 @@ good job :)
 col@ubuntu:~$ ./col `python -c 'print "\xe8\x05\xd9\x1d" + "\x01"*16'`
 ````
 
-**Note:** `0x1dd905e8 + 4*0x01010101 = 0x21dd09ec`
+> **Note:** `0x1dd905e8 + 4*0x01010101 = 0x21dd09ec`
+{: .prompt-info }
 
 ## bof
 
@@ -438,4 +440,5 @@ r.sendline(shell_address + "A"*12 + p32(int(stack_address, 16) + 12) + p32(int(h
 r.interactive()
 ```
 
-**Go through other [writeups](/writeups/) for more such fun challenges.**
+> Go through other [writeups](/writeups/) for more such fun challenges.
+{: .prompt-tip }

--- a/_posts/2017-08-03-writeup-bugs_bunny_rev75.md
+++ b/_posts/2017-08-03-writeup-bugs_bunny_rev75.md
@@ -16,12 +16,10 @@ description: "Reversing a binary with XOR-encoded flag hidden in a lookup table"
 ctf_category: Reversing
 ---
 
-#### Points: 75
-
-#### Description:
-
-> i ran the binary but no password match but believe this is another simple reverse engineering challenge .
+> **Challenge:** i ran the binary but no password match but believe this is another simple reverse engineering challenge .
 [rev75.zip](/assets/binaries/bugs_bunny_2k17/rev75.zip)
+
+## Write-up
 
 This was an interested challenge, which helped me learn some more of pwntools.
 
@@ -60,4 +58,5 @@ Note that I didn't know in advance that the base64 string will give a PNG image.
 
 Open `flag.png` and you have your flag.
 
-**Go through other [writeups](/writeups/) for more such fun challenges.**
+> Go through other [writeups](/writeups/) for more such fun challenges.
+{: .prompt-tip }

--- a/_posts/2017-08-25-csec-binary-exploitation-1.md
+++ b/_posts/2017-08-25-csec-binary-exploitation-1.md
@@ -28,8 +28,9 @@ Liked it ??? Didn't like it ????? Let me know!
 
 Constructive criticism is much appreciated.
 
-**Cheers!**
+Cheers!
 
-**If you are an Infosec person, don't forget to checkout my [CTF Write-ups](/writeups/)**
+> If you are an Infosec person, don't forget to checkout my [CTF Write-ups](/writeups/).
+{: .prompt-tip }
 
 [See other Blog posts](/blog/)

--- a/_posts/2017-10-18-Ubisoft-GameJam-Winners.md
+++ b/_posts/2017-10-18-Ubisoft-GameJam-Winners.md
@@ -41,8 +41,9 @@ The code for our game is open source and available [here](https://github.com/Fer
 
 Thank you for reading!
 
-**Cheers!**
+Cheers!
 
-**If you are an Infosec person, don't forget to checkout my [CTF Write-ups](/writeups/)**
+> If you are an Infosec person, don't forget to checkout my [CTF Write-ups](/writeups/).
+{: .prompt-tip }
 
 [See other Blog posts](/blog/)

--- a/_posts/2017-10-18-writeup-backdoorctf17-1ecb.md
+++ b/_posts/2017-10-18-writeup-backdoorctf17-1ecb.md
@@ -16,13 +16,10 @@ ctf_category: Crypto
 description: "BackdoorCTF 2017 ECB: exploiting AES-ECB pattern leakage to reveal an encrypted image flag"
 ---
 
-**BackdoorCTF is the annual flagship CTF competition conducted by SDSLabs and InfoSecIITR.**
+> BackdoorCTF is the annual flagship CTF competition conducted by SDSLabs and InfoSecIITR.
+{: .prompt-info }
 
-#### Points: 150
-
-#### Description:
-
-> n00b learnt about ECB and has encrypted some images with it. Can you find the flag?
+> **Challenge:** n00b learnt about ECB and has encrypted some images with it. Can you find the flag?
 
 >    [img1.png](/assets/images/backdoorctf17/img1.png)
     [img2.png](/assets/images/backdoorctf17/img2.png)
@@ -30,7 +27,7 @@ description: "BackdoorCTF 2017 ECB: exploiting AES-ECB pattern leakage to reveal
 
 ## Background
 
-**"Everybody knows ECB mode is bad because we can see the penguin!"**
+> "Everybody knows ECB mode is bad because we can see the penguin!"
 
 If you haven't heard about the famous ECB penguin before, you probably haven't heard about ECB either.
 
@@ -130,4 +127,5 @@ And voila!
 
 **Flag:** `CTF{0n1y_n00b5_u53_3cb}`
 
-**Go through other [writeups](/writeups/) for more such fun challenges.**
+> Go through other [writeups](/writeups/) for more such fun challenges.
+{: .prompt-tip }

--- a/_posts/2017-10-19-writeup-backdoorctf17-2funsignals.md
+++ b/_posts/2017-10-19-writeup-backdoorctf17-2funsignals.md
@@ -16,13 +16,10 @@ ctf_category: Pwn
 description: "BackdoorCTF 2017 Fun Signals: using Linux signal handlers as a ret2syscall exploit primitive"
 ---
 
-**BackdoorCTF is the annual flagship CTF competition conducted by SDSLabs and InfoSecIITR.**
+> BackdoorCTF is the annual flagship CTF competition conducted by SDSLabs and InfoSecIITR.
+{: .prompt-info }
 
-#### Points: 250
-
-#### Description:
-
-> Gr33n5h4d0w had an argument with h3rcul35 while they were studying Signals and Systems. So, h3rcul35 gave him a binary and said "Signals control Computer. Give me the flag". Can you help gr33n5h4d0w win his argument by helping him get the flag.
+> **Challenge:** Gr33n5h4d0w had an argument with h3rcul35 while they were studying Signals and Systems. So, h3rcul35 gave him a binary and said "Signals control Computer. Give me the flag". Can you help gr33n5h4d0w win his argument by helping him get the flag.
 
 > ~~nc hack.bckdr.in 9034~~ *(CTF server no longer available)*
 
@@ -90,8 +87,10 @@ r.interactive()
 
 This will connect to the server, extract the flag and print it.
 
-**Note:** I randomly decided to get 50 characters since we don't know the flag size beforehand. The flag was actually smaller than that. Anything larger than the flag size would've worked.
+> **Note:** I randomly decided to get 50 characters since we don't know the flag size beforehand. The flag was actually smaller than that. Anything larger than the flag size would've worked.
+{: .prompt-info }
 
 Cheers!
 
-**Go through other [writeups](/writeups/) for more such fun challenges.**
+> Go through other [writeups](/writeups/) for more such fun challenges.
+{: .prompt-tip }

--- a/_posts/2017-11-08-csec-binary-exploitation-2.md
+++ b/_posts/2017-11-08-csec-binary-exploitation-2.md
@@ -27,8 +27,9 @@ Don't miss the demo at the end!
 
 Constructive criticism is much appreciated.
 
-**Cheers!**
+Cheers!
 
-**If you are an Infosec person, don't forget to checkout my [CTF Write-ups](/writeups/)**
+> If you are an Infosec person, don't forget to checkout my [CTF Write-ups](/writeups/).
+{: .prompt-tip }
 
 [See other Blog posts](/blog/)

--- a/_posts/2017-12-13-indexing-schemes.md
+++ b/_posts/2017-12-13-indexing-schemes.md
@@ -13,7 +13,7 @@ projects: true
 description: "Implementing stepped-merge indexes inside PostgreSQL's C codebase from a 1997 research paper"
 ---
 
-# Project Report
+## Project Report
 
 | Team DataAcids  | |
 | ------------- | ------------- |
@@ -45,11 +45,11 @@ The reference paper for the project can be found [here](https://www.cse.iitb.ac.
 
 ## System Architecture
 
-**Front-end**
+### Front-end
 
 - There is no real front-end we will implement. It is just the user interface that PostgreSQL provide.
 
-**Back-end**
+### Back-end
 
 1. Implemented a structure similar to Log Structured Merge trees(Stepped Merge Trees) to organize the incoming data on the basis of clustering by search key.
 - Worked in single-user mode

--- a/_posts/2017-12-23-right-way-to-use-sublime-text.md
+++ b/_posts/2017-12-23-right-way-to-use-sublime-text.md
@@ -46,8 +46,9 @@ So let's get started!
 
 Again, do try all this out by yourself!
 
-**Cheers!**
+Cheers!
 
-**If you are an Infosec person, don't forget to checkout my [CTF Write-ups](/writeups/)**
+> If you are an Infosec person, don't forget to checkout my [CTF Write-ups](/writeups/).
+{: .prompt-tip }
 
 [See other Blog posts](/blog/)

--- a/_posts/2018-04-18-my-other-computer-is-your-computer.md
+++ b/_posts/2018-04-18-my-other-computer-is-your-computer.md
@@ -15,10 +15,10 @@ description: "Classifying malware into 9 families using ML on assembly code and 
 
 ## Background
 
-#### Why this project?
+### Why this project?
 This project emerged for fulfilling a requirement of the Machine Learning course (EE 769) I took this semester. As I have always been interested in computer security, I wanted to combine my newly learnt knowledge from this course with it. The attacks last year from malwares like [WannaCry](https://en.wikipedia.org/wiki/WannaCry_ransomware_attack), [NotPetya](https://en.wikipedia.org/wiki/Petya_(malware_family)#2017_Cyberattack) and [Bad Rabbit](https://www.kaspersky.com/blog/bad-rabbit-ransomware/19887/) had made me curious about how these attacks could be prevented. Malware Classification was the perfect project. For this I teamed up with my good friend Mukesh Pareek who is also a security enthusiast. This post is written in collaboration with him. Our guide for this project is [Prof. Amit Sethi](https://www.ee.iitb.ac.in/~asethi/).
 
-#### Malware
+### Malware
 
 ![Malware Classes](/assets/images/malware/classes.jpg)
 
@@ -43,17 +43,17 @@ We focused on solving the second problem.
 But why classify malware into classes? Just like a doctor can treat you better if he/she knows what disease you have, anti-malware softwares like antiviruses can defend better if they know the class of malware they are dealing with.
 
 
-#### Challenges
+### Challenges
 
 Earlier malware was detected using signatures. So whenever there a new malware was found, the companies created its signature and any file whose signature matched was detected. Since this method could only find exact matches, it was very restrictive. Later people shifted to identifying "indicators" which were the defining properties of a class of malware. So if a file had certain indicators it could be classified to the corresponding class. But this again uses only known indicators. With new methods to obfuscate and polymorphism techniques, the creators of these malwares were easily able to get across this layer of protection. The problems we face today is that millions of samples of malware spread everyday. Most of these are duplicates or slight modifications of one another made to decieve the defense systems. Classifying malware thus becomes a daunting task.
 
 
-#### Why Machine Learning?
+### Why Machine Learning?
 
 In today's data rich world, machine learning has become ubiquitous. With its ability to find useful pieces of information from data, machine learning has lead to great results. The defense against a malware attack depends on the broader category of malware and not necessarily on the specific attack sample. This is why machine learning can be used. It can find hidden relationships among the various features of the samples and then leverage those to classify unknown samples. 
 
 
-#### More specifically...
+### More specifically...
 
 Now we come to what exactly is the information we have about the malware and what categories do we need to classify it to.
 
@@ -81,7 +81,7 @@ So these two files need to be used to classify the malware into the following 9 
 8. Obfuscator.ACY
 9. Gatak
 
-#### The dataset
+### The dataset
 
 The specific problem as stated above is taken from a [malware classification challenge](https://www.kaggle.com/c/malware-classification) organised by Microsoft on Kaggle. The dataset was also taken from there. The dataset contained 200 GB of training data and 200 GB of test data. Since we didn't have the labels for the test data, we divided the training data itself into two parts one of which we used for testing purposes. The testing part was half the size of the training part with training having 7221 samples and test having 3648 labels. This divison was done randomly but ensuring that enough members of each class were are a part of both the training and test set.
 
@@ -105,7 +105,7 @@ The features we used for classification are as follows:
 
 Our intuition behind using instruction n-grams was that samples from the same class of malware should have similar code and hence there should be similar instructions sequences present in the code. n-grams were a way to represent that. Likewise for the byte n-grams. Using segment size is again based on the intuition that the amount of static data, the amount of space required for the code would be similar for the same class.
 
-#### Implementation details
+### Implementation details
 
 Extracting the above features involves text processing and parsing. For this we used the `pyparsing` python library. The library can be used to specify token formats which make it easier to identify the required instructions or bytes. For getting an image from the `.asm` file we used byte arrays.
 
@@ -130,7 +130,7 @@ For each of these models we did hyperparameter tuning to find out the best model
 
 ## Evaluation
 
-#### Hyperparameter Tuning
+### Hyperparameter Tuning
 
 The graphs for hyperparameter tuning are as follows:
 
@@ -153,7 +153,7 @@ The graphs for hyperparameter tuning are as follows:
 
 ![Feature importance]() -->
 
-#### Cross Validation and Test Set Accuracy
+### Cross Validation and Test Set Accuracy
 
 | Model                      | 4-Fold Cross Validation Accuracy | Test Set Accuracy |
 |--------------------------------|------------------------------------|-------------------|

--- a/_posts/2018-06-06-spamslam.md
+++ b/_posts/2018-06-06-spamslam.md
@@ -14,7 +14,8 @@ projects: true
 description: "What if sending email cost a digital stamp? Our blockchain hack won first place at HackInOut"
 ---
 
-**Note:** A post elaborating on my experience at this hackathon was published [here](https://devfolio.co/blog/spamslam-a-blockchain-solution-to-less-spam/)
+> **Note:** A post elaborating on my experience at this hackathon was published [here](https://devfolio.co/blog/spamslam-a-blockchain-solution-to-less-spam/).
+{: .prompt-info }
 
 This project was done as part of [Hack InOut](https://hackinout.co/), a 30 hour hackathon held at Bengaluru in Fall 2017. There was a blockchain track and we had never explored this trending technology before, so we figured we would do something in this space. However, our idea can be implemented, and perhaps in a better manner, without blockchain as well. With due gratitude to Gnosis who sponsored the first prize that we got in the Blockchain Track, and whose platform we used in the hackathon implementation, I would discuss the idea independent of an implementation.
 


### PR DESCRIPTION
## Post reading polish sweep — headings + callouts across legacy posts

Extends the af2.41 reading-polish conventions to the remaining flagged posts. This is a **content-only** change (no CSS/layout): it fixes broken heading hierarchies and replaces `####` metadata headings and whole-paragraph bold "pseudo-callouts" with idiomatic Chirpy `.prompt-*` callouts, reserving blockquotes for genuine quotes.

Closes beads **af2.47**.

### What changed

**CTF write-ups** (infosec n00b 1–3, backdoorctf16 0–6, backdoorctf17 ecb/funsignals, bugs_bunny, pwnablekr)
- Dropped redundant `#### Points:` — the value already renders in the post meta row (🏆 N pts).
- `#### Description:` → labelled `> **Challenge:**` blockquote.
- Recurring CTF intro → `.prompt-info`; "other write-ups" sign-off → `.prompt-tip`.
- `#### Flag:` → bold label; added a `## Write-up` heading where one was missing.

**Blog/project posts** (importance-of-quotes, printing-emojis, did-i-execute, indexing-schemes, right-way-to-use-sublime-text, my-other-computer)
- Fixed heading hierarchy: bold section labels and stray `#`/`####` headings become proper `##`/`###`.
- Informational bold paragraphs → `.prompt-info` / `.prompt-tip` callouts.

**Misc consistency**
- Normalised the "Cheers!" / "checkout my write-ups" sign-offs (csec 1/2, Ubisoft, sublime) — unbolded chatter, CTA as `.prompt-tip`.
- Promoted in-prose Bandit Edit/Note asides (levels 6/8/13/15) and stray Update/Note notes (how-to-crack-wifi, spamslam) to callouts.

29 posts, +117 / −130. Each post was reviewed individually (not blindly scripted). Verified with a production Jekyll build; callouts and heading levels render correctly.

### Before / After

Six representative posts, one per distinct change type. "Before" is the live site; "after" is the local production build.

**CTF write-up — dropped metadata headings (BackdoorCTF 2017 · ECB):** redundant `Points:`/`Description:` headings (which also cluttered the Contents TOC) become a clean `.prompt-info` intro, a labelled `Challenge:` blockquote, and a tidy TOC.

| Before (live) | After (local) |
| --- | --- |
| ![before](https://github.com/CodeMaxx/CodeMaxx.github.io/releases/download/pr-assets/af2-47-1ecb-before.png) | ![after](https://github.com/CodeMaxx/CodeMaxx.github.io/releases/download/pr-assets/af2-47-1ecb-after.png) |

**Blog post — inline pseudo-callout (Did I Execute?):** the bold-lead "**Note** that…" paragraph becomes a proper `.prompt-info` callout, and the section headings move from `### **bold**` to clean `##`.

| Before (live) | After (local) |
| --- | --- |
| ![before](https://github.com/CodeMaxx/CodeMaxx.github.io/releases/download/pr-assets/af2-47-did-before.png) | ![after](https://github.com/CodeMaxx/CodeMaxx.github.io/releases/download/pr-assets/af2-47-did-after.png) |

**Blog post — bold labels → real headings (Importance of quotes in Terminal):** the shouting `**NO QUOTES**` / `**DOUBLE QUOTES**` pseudo-headings become `## No quotes` / `## Double quotes` — which now populate the (previously empty) Contents TOC.

| Before (live) | After (local) |
| --- | --- |
| ![before](https://github.com/CodeMaxx/CodeMaxx.github.io/releases/download/pr-assets/af2-47-quotes-before.png) | ![after](https://github.com/CodeMaxx/CodeMaxx.github.io/releases/download/pr-assets/af2-47-quotes-after.png) |

**Project report — heading hierarchy (Indexing Schemes):** the page's lone `#` (h1, duplicating the post title) becomes `##`, so "Project Report" now anchors the outline correctly, and `**Front-end**`/`**Back-end**` become `###`.

| Before (live) | After (local) |
| --- | --- |
| ![before](https://github.com/CodeMaxx/CodeMaxx.github.io/releases/download/pr-assets/af2-47-indexing-before.png) | ![after](https://github.com/CodeMaxx/CodeMaxx.github.io/releases/download/pr-assets/af2-47-indexing-after.png) |

**CTF write-up — intro + inline note callouts (pwnable.kr · Toddler's Bottle):** the bold intro paragraph becomes a `.prompt-info` banner and the inline `**Note:**` becomes a `.prompt-info` box.

| Before (live) | After (local) |
| --- | --- |
| ![before](https://github.com/CodeMaxx/CodeMaxx.github.io/releases/download/pr-assets/af2-47-pwnablekr-before.png) | ![after](https://github.com/CodeMaxx/CodeMaxx.github.io/releases/download/pr-assets/af2-47-pwnablekr-after.png) |

**Bandit write-up — warning callout (OverTheWire · Bandit Level 13):** the bold `**Note that you need to change permission…**` aside becomes a `.prompt-warning` (amber) callout.

| Before (live) | After (local) |
| --- | --- |
| ![before](https://github.com/CodeMaxx/CodeMaxx.github.io/releases/download/pr-assets/af2-47-bandit13-before.png) | ![after](https://github.com/CodeMaxx/CodeMaxx.github.io/releases/download/pr-assets/af2-47-bandit13-after.png) |
