### PR TITLE
SEO: keyword-rich titles and descriptions for legacy posts

### DIFF
--- a/_posts/2016-04-03-checking-out-stuff.md
+++ b/_posts/2016-04-03-checking-out-stuff.md
@@ -5,6 +5,7 @@ date: 2016-04-03 12:00
 tags:
 - Personal
 blog: true
+description: "My first blog post — introducing myself and why I started writing about coding and computer science."
 ---
 
 ## <center> So this should work </center>

--- a/_posts/2016-05-10-SymEngine.md
+++ b/_posts/2016-05-10-SymEngine.md
@@ -7,7 +7,7 @@ tags:
 - Cpp
 - Computer Algebra
 projects: true
-description: "Symbolic Computation C++ Library"
+description: "My open-source work on SymEngine, a standalone fast C++ symbolic manipulation (computer algebra) library."
 ---
 
 <center>A standalone fast C++ symbolic manipulation library.</center>

--- a/_posts/2016-05-10-sympy.md
+++ b/_posts/2016-05-10-sympy.md
@@ -10,7 +10,7 @@ tags:
 - Python
 - Computer Algebra
 projects: true
-description: "Symbolic Computation Python Library"
+description: "My open-source contributions to SymPy, the Python library for symbolic mathematics and computer algebra."
 ---
 
 

--- a/_posts/2016-05-10-wptview.md
+++ b/_posts/2016-05-10-wptview.md
@@ -10,7 +10,7 @@ tags:
 - Web Development
 - AngularJS
 projects: true
-description: "Web Platform Test Viewer"
+description: "My AngularJS contributions to wptview, Mozilla's web app for viewing Web Platform Test results."
 ---
 
 <center>Mozilla's webapp for displaying the results of Web-platform Tests.</center>

--- a/_posts/2016-05-16-writeup-infosec_institute_n00b_ctf-level1.md
+++ b/_posts/2016-05-16-writeup-infosec_institute_n00b_ctf-level1.md
@@ -11,7 +11,7 @@ tags:
 - Web Security
 - Infosec Institute n00b CTF
 writeup: true
-description: "n00b CTF 1"
+description: "Spotting the hidden flag by viewing the page's HTML source."
 points: 10
 ctf_category: Web
 ---

--- a/_posts/2016-05-16-writeup-infosec_institute_n00b_ctf-level2.md
+++ b/_posts/2016-05-16-writeup-infosec_institute_n00b_ctf-level2.md
@@ -11,7 +11,7 @@ tags:
 - Web Security
 - Infosec Institute n00b CTF
 writeup: true
-description: "n00b CTF 2"
+description: "Using the file command to unmask a fake broken image and recover the flag."
 points: 20
 ctf_category: Web
 ---

--- a/_posts/2016-05-16-writeup-infosec_institute_n00b_ctf-level3.md
+++ b/_posts/2016-05-16-writeup-infosec_institute_n00b_ctf-level3.md
@@ -11,7 +11,7 @@ tags:
 - Web Security
 - Infosec Institute n00b CTF
 writeup: true
-description: "n00b CTF 3"
+description: "Decoding a QR code and then Morse code to reveal the flag."
 points: 30
 ctf_category: Web
 ---

--- a/_posts/2016-05-31-writeup-overthewire-bandit-level00.md
+++ b/_posts/2016-05-31-writeup-overthewire-bandit-level00.md
@@ -1,5 +1,5 @@
 ---
-title: "Bandit Level 0"
+title: "OverTheWire Bandit Level 0 → 1 Walkthrough"
 layout: post
 permalink: /writeups/OverTheWire/Bandit/level00/
 date: 2016-05-31 01:16:51 +0530
@@ -13,7 +13,7 @@ tags:
 writeup: true
 points:
 ctf_category: Wargame
-description: "Bandit Level 0 → 1: logging into SSH and reading a file with cat"
+description: "Logging into SSH and reading a file with cat"
 ---
 
 > **Level goal:** The password for the next level is stored in a file called **readme** located in the home directory. Use this password to log into bandit1 using SSH. Whenever you find a password for a level, use SSH to log into that level and continue the game.

--- a/_posts/2016-05-31-writeup-overthewire-bandit-level01.md
+++ b/_posts/2016-05-31-writeup-overthewire-bandit-level01.md
@@ -1,5 +1,5 @@
 ---
-title: "Bandit Level 1"
+title: "OverTheWire Bandit Level 1 → 2 Walkthrough"
 layout: post
 permalink: /writeups/OverTheWire/Bandit/level01/
 date: 2016-05-31 01:16:51 +0530
@@ -13,7 +13,7 @@ tags:
 writeup: true
 points:
 ctf_category: Wargame
-description: "Bandit Level 1 → 2: reading a file named with a dash using a path prefix"
+description: "Reading a file named with a dash using a path prefix"
 ---
 
 > **Level goal:** The password for the next level is stored in a file called `-` located in the home directory

--- a/_posts/2016-05-31-writeup-overthewire-bandit-level02.md
+++ b/_posts/2016-05-31-writeup-overthewire-bandit-level02.md
@@ -1,5 +1,5 @@
 ---
-title: "Bandit Level 2"
+title: "OverTheWire Bandit Level 2 → 3 Walkthrough"
 layout: post
 permalink: /writeups/OverTheWire/Bandit/level02/
 date: 2016-05-31 01:16:51 +0530
@@ -13,7 +13,7 @@ tags:
 writeup: true
 points:
 ctf_category: Wargame
-description: "Bandit Level 2 → 3: reading a filename with spaces using quotes or backslash"
+description: "Reading a filename with spaces using quotes or backslash"
 ---
 
 > **Level goal:** The password for the next level is stored in a file called spaces in this filename located in the home directory

--- a/_posts/2016-05-31-writeup-overthewire-bandit-level03.md
+++ b/_posts/2016-05-31-writeup-overthewire-bandit-level03.md
@@ -1,5 +1,5 @@
 ---
-title: "Bandit Level 3"
+title: "OverTheWire Bandit Level 3 → 4 Walkthrough"
 layout: post
 permalink: /writeups/OverTheWire/Bandit/level03/
 date: 2016-05-31 01:16:51 +0530
@@ -13,7 +13,7 @@ tags:
 writeup: true
 points:
 ctf_category: Wargame
-description: "Bandit Level 3 → 4: finding and reading a hidden file with ls -a"
+description: "Finding and reading a hidden file with ls -a"
 ---
 
 > **Level goal:** The password for the next level is stored in a hidden file in the inhere directory.

--- a/_posts/2016-05-31-writeup-overthewire-bandit-level04.md
+++ b/_posts/2016-05-31-writeup-overthewire-bandit-level04.md
@@ -1,5 +1,5 @@
 ---
-title: "Bandit Level 4"
+title: "OverTheWire Bandit Level 4 → 5 Walkthrough"
 layout: post
 permalink: /writeups/OverTheWire/Bandit/level04/
 date: 2016-05-31 01:16:51 +0530
@@ -13,7 +13,7 @@ tags:
 writeup: true
 points:
 ctf_category: Wargame
-description: "Bandit Level 4 → 5: using the file command to find the only human-readable file"
+description: "Using the file command to find the only human-readable file"
 ---
 
 > **Level goal:** The password for the next level is stored in the only human-readable file in the inhere directory. Tip: if your terminal is messed up, try the “reset” command.

--- a/_posts/2016-05-31-writeup-overthewire-bandit-level05.md
+++ b/_posts/2016-05-31-writeup-overthewire-bandit-level05.md
@@ -1,5 +1,5 @@
 ---
-title: "Bandit Level 5"
+title: "OverTheWire Bandit Level 5 → 6 Walkthrough"
 layout: post
 permalink: /writeups/OverTheWire/Bandit/level05/
 date: 2016-05-31 01:16:51 +0530
@@ -13,7 +13,7 @@ tags:
 writeup: true
 points:
 ctf_category: Wargame
-description: "Bandit Level 5 → 6: using find with size and non-executable flags to locate the password"
+description: "Using find with a size filter to locate the password among many decoy files"
 ---
 
 > **Level goal:** The password for the next level is stored in a file somewhere under the inhere directory and has all of the following properties: - human-readable - 1033 bytes in size - not executable

--- a/_posts/2016-05-31-writeup-overthewire-bandit-level06.md
+++ b/_posts/2016-05-31-writeup-overthewire-bandit-level06.md
@@ -1,5 +1,5 @@
 ---
-title: "Bandit Level 6"
+title: "OverTheWire Bandit Level 6 → 7 Walkthrough"
 layout: post
 permalink: /writeups/OverTheWire/Bandit/level06/
 date: 2016-05-31 01:16:51 +0530
@@ -13,7 +13,7 @@ tags:
 writeup: true
 points:
 ctf_category: Wargame
-description: "Bandit Level 6 → 7: searching the whole server by owner, group, and size with find"
+description: "Searching the whole server by owner, group, and size with find"
 ---
 
 > **Level goal:** The password for the next level is stored somewhere on the server and has all of the following properties: - owned by user bandit7 - owned by group bandit6 - 33 bytes in size

--- a/_posts/2016-05-31-writeup-overthewire-bandit-level07.md
+++ b/_posts/2016-05-31-writeup-overthewire-bandit-level07.md
@@ -1,5 +1,5 @@
 ---
-title: "Bandit Level 7"
+title: "OverTheWire Bandit Level 7 → 8 Walkthrough"
 layout: post
 permalink: /writeups/OverTheWire/Bandit/level07/
 date: 2016-05-31 01:16:51 +0530
@@ -13,7 +13,7 @@ tags:
 writeup: true
 points:
 ctf_category: Wargame
-description: "Bandit Level 7 → 8: extracting a password next to the word 'millionth' with grep"
+description: "Extracting a password next to the word 'millionth' with grep"
 ---
 
 > **Level goal:** The password for the next level is stored in the file **data.txt** next to the word **millionth**

--- a/_posts/2016-05-31-writeup-overthewire-bandit-level08.md
+++ b/_posts/2016-05-31-writeup-overthewire-bandit-level08.md
@@ -1,5 +1,5 @@
 ---
-title: "Bandit Level 8"
+title: "OverTheWire Bandit Level 8 → 9 Walkthrough"
 layout: post
 permalink: /writeups/OverTheWire/Bandit/level08/
 date: 2016-05-31 01:16:51 +0530
@@ -13,7 +13,7 @@ tags:
 writeup: true
 points:
 ctf_category: Wargame
-description: "Bandit Level 8 → 9: finding the only unique line in a file using sort and uniq -u"
+description: "Finding the only unique line in a file using sort and uniq -u"
 ---
 
 > **Level goal:** The password for the next level is stored in the file data.txt and is the only line of text that occurs only once

--- a/_posts/2016-05-31-writeup-overthewire-bandit-level09.md
+++ b/_posts/2016-05-31-writeup-overthewire-bandit-level09.md
@@ -1,5 +1,5 @@
 ---
-title: "Bandit Level 9"
+title: "OverTheWire Bandit Level 9 → 10 Walkthrough"
 layout: post
 permalink: /writeups/OverTheWire/Bandit/level09/
 date: 2016-05-31 01:16:51 +0530
@@ -13,7 +13,7 @@ tags:
 writeup: true
 points:
 ctf_category: Wargame
-description: "Bandit Level 9 → 10: using strings to extract human-readable text from a binary file"
+description: "Using strings to extract human-readable text from a binary file"
 ---
 
 > **Level goal:** The password for the next level is stored in the file data.txt in one of the few human-readable strings, beginning with several ‘=’ characters.

--- a/_posts/2016-05-31-writeup-overthewire-bandit-level10.md
+++ b/_posts/2016-05-31-writeup-overthewire-bandit-level10.md
@@ -1,5 +1,5 @@
 ---
-title: "Bandit Level 10"
+title: "OverTheWire Bandit Level 10 → 11 Walkthrough"
 layout: post
 permalink: /writeups/OverTheWire/Bandit/level10/
 date: 2016-05-31 00:41:51 +0530
@@ -13,7 +13,7 @@ tags:
 writeup: true
 points:
 ctf_category: Wargame
-description: "Bandit Level 10 → 11: decoding base64-encoded data with the base64 command"
+description: "Decoding base64-encoded data with the base64 command"
 ---
 
 > **Level goal:** The password for the next level is stored in the file data.txt, which contains base64 encoded data

--- a/_posts/2016-05-31-writeup-overthewire-bandit-level11.md
+++ b/_posts/2016-05-31-writeup-overthewire-bandit-level11.md
@@ -1,5 +1,5 @@
 ---
-title: "Bandit Level 11"
+title: "OverTheWire Bandit Level 11 → 12 Walkthrough"
 layout: post
 permalink: /writeups/OverTheWire/Bandit/level11/
 date: 2016-05-31 00:41:51 +0530
@@ -13,7 +13,7 @@ tags:
 writeup: true
 points:
 ctf_category: Wargame
-description: "Bandit Level 11 → 12: decoding a ROT13 cipher using the tr command"
+description: "Decoding a ROT13 cipher using the tr command"
 ---
 
 > **Level goal:** The password for the next level is stored in the file data.txt, where all lowercase (a-z) and uppercase (A-Z) letters have been rotated by 13 positions

--- a/_posts/2016-05-31-writeup-overthewire-bandit-level12.md
+++ b/_posts/2016-05-31-writeup-overthewire-bandit-level12.md
@@ -1,5 +1,5 @@
 ---
-title: "Bandit Level 12"
+title: "OverTheWire Bandit Level 12 → 13 Walkthrough"
 layout: post
 permalink: /writeups/OverTheWire/Bandit/level12/
 date: 2016-05-31 00:41:51 +0530
@@ -13,7 +13,7 @@ tags:
 writeup: true
 points:
 ctf_category: Wargame
-description: "Bandit Level 12 → 13: decompressing a repeatedly-compressed hexdump with xxd, gzip, bzip2, and tar"
+description: "Decompressing a repeatedly-compressed hexdump with xxd, gzip, bzip2, and tar"
 ---
 
 > **Level goal:** The password for the next level is stored in the file data.txt, which is a hexdump of a file that has been repeatedly compressed. For this level it may be useful to create a directory under /tmp in which you can work using mkdir. For example: mkdir /tmp/myname123. Then copy the datafile using cp, and rename it using mv (read the manpages!)

--- a/_posts/2016-05-31-writeup-overthewire-bandit-level13.md
+++ b/_posts/2016-05-31-writeup-overthewire-bandit-level13.md
@@ -1,5 +1,5 @@
 ---
-title: "Bandit Level 13"
+title: "OverTheWire Bandit Level 13 → 14 Walkthrough"
 layout: post
 permalink: /writeups/OverTheWire/Bandit/level13/
 date: 2016-05-31 00:41:51 +0530
@@ -13,7 +13,7 @@ tags:
 writeup: true
 points:
 ctf_category: Wargame
-description: "Bandit Level 13 → 14: using an SSH private key to log in without a password"
+description: "Using an SSH private key to log in without a password"
 ---
 
 > **Level goal:** The password for the next level is stored in /etc/bandit_pass/bandit14 and can only be read by user bandit14. For this level, you don’t get the next password, but you get a private SSH key that can be used to log into the next level. Note: localhost is a hostname that refers to the machine you are working on

--- a/_posts/2016-05-31-writeup-overthewire-bandit-level14.md
+++ b/_posts/2016-05-31-writeup-overthewire-bandit-level14.md
@@ -1,5 +1,5 @@
 ---
-title: "Bandit Level 14"
+title: "OverTheWire Bandit Level 14 → 15 Walkthrough"
 layout: post
 permalink: /writeups/OverTheWire/Bandit/level14/
 date: 2016-05-31 00:41:51 +0530
@@ -13,7 +13,7 @@ tags:
 writeup: true
 points:
 ctf_category: Wargame
-description: "Bandit Level 14 → 15: submitting a password to a localhost port using netcat"
+description: "Submitting a password to a localhost port using netcat"
 ---
 
 > **Level goal:** The password for the next level can be retrieved by submitting the password of the current level to **port 30000 on localhost**.

--- a/_posts/2016-05-31-writeup-overthewire-bandit-level15.md
+++ b/_posts/2016-05-31-writeup-overthewire-bandit-level15.md
@@ -1,5 +1,5 @@
 ---
-title: "Bandit Level 15"
+title: "OverTheWire Bandit Level 15 → 16 Walkthrough"
 layout: post
 permalink: /writeups/OverTheWire/Bandit/level15/
 date: 2016-05-31 04:37:00 +0530
@@ -13,7 +13,7 @@ tags:
 writeup: true
 points:
 ctf_category: Wargame
-description: "Bandit Level 15 → 16: submitting a password over SSL using openssl s_client"
+description: "Submitting a password over SSL using openssl s_client"
 ---
 
 > **Level goal:** The password for the next level can be retrieved by submitting the password of the current level to port 30001 on localhost using SSL encryption.

--- a/_posts/2016-05-31-writeup-overthewire-bandit-level16.md
+++ b/_posts/2016-05-31-writeup-overthewire-bandit-level16.md
@@ -1,5 +1,5 @@
 ---
-title: "Bandit Level 16"
+title: "OverTheWire Bandit Level 16 → 17 Walkthrough"
 layout: post
 permalink: /writeups/OverTheWire/Bandit/level16/
 date: 2016-05-31 04:37:00 +0530
@@ -13,7 +13,7 @@ tags:
 writeup: true
 points:
 ctf_category: Wargame
-description: "Bandit Level 16 → 17: port scanning with nmap to find the SSL listener and get an SSH key"
+description: "Port scanning with nmap to find the SSL listener and get an SSH key"
 ---
 
 > **Level goal:** The credentials for the next level can be retrieved by submitting the password of the current level to a port on localhost in the range 31000 to 32000. First find out which of these ports have a server listening on them. Then find out which of those speak SSL and which don’t. There is only 1 server that will give the next credentials, the others will simply send back to you whatever you send to it.

--- a/_posts/2016-05-31-writeup-overthewire-bandit-level17.md
+++ b/_posts/2016-05-31-writeup-overthewire-bandit-level17.md
@@ -1,5 +1,5 @@
 ---
-title: "Bandit Level 17"
+title: "OverTheWire Bandit Level 17 → 18 Walkthrough"
 layout: post
 permalink: /writeups/OverTheWire/Bandit/level17/
 date: 2016-05-31 04:37:00 +0530
@@ -13,7 +13,7 @@ tags:
 writeup: true
 points:
 ctf_category: Wargame
-description: "Bandit Level 17 → 18: using diff to find the one changed line between two password files"
+description: "Using diff to find the one changed line between two password files"
 ---
 
 > **Level goal:** There are 2 files in the homedirectory: passwords.old and passwords.new. The password for the next level is in passwords.new and is the only line that has been changed between passwords.old and passwords.new

--- a/_posts/2016-06-02-writeup-overthewire-bandit-level18.md
+++ b/_posts/2016-06-02-writeup-overthewire-bandit-level18.md
@@ -1,5 +1,5 @@
 ---
-title: "Bandit Level 18"
+title: "OverTheWire Bandit Level 18 → 19 Walkthrough"
 layout: post
 permalink: /writeups/OverTheWire/Bandit/level18/
 date: 2016-06-02 22:45:50 +0530
@@ -13,7 +13,7 @@ tags:
 writeup: true
 points:
 ctf_category: Wargame
-description: "Bandit Level 18 → 19: bypassing .bashrc logout by running a command directly over SSH"
+description: "Bypassing .bashrc logout by running a command directly over SSH"
 ---
 
 > **Level goal:** The password for the next level is stored in a file **readme** in the homedirectory. Unfortunately, someone has modified **.bashrc** to log you out when you log in with SSH.

--- a/_posts/2016-06-02-writeup-overthewire-bandit-level19.md
+++ b/_posts/2016-06-02-writeup-overthewire-bandit-level19.md
@@ -1,5 +1,5 @@
 ---
-title: "Bandit Level 19"
+title: "OverTheWire Bandit Level 19 → 20 Walkthrough"
 layout: post
 permalink: /writeups/OverTheWire/Bandit/level19/
 date: 2016-06-02 22:45:50 +0530
@@ -13,7 +13,7 @@ tags:
 writeup: true
 points:
 ctf_category: Wargame
-description: "Bandit Level 19 → 20: using a setuid binary to read a file owned by another user"
+description: "Using a setuid binary to read a file owned by another user"
 ---
 
 > **Level goal:** To gain access to the next level, you should use the setuid binary in the homedirectory. Execute it without arguments to find out how to use it. The password for this level can be found in the usual place (/etc/bandit_pass), after you have used to setuid binary.

--- a/_posts/2016-06-15-different-kinds-of-executables.md
+++ b/_posts/2016-06-15-different-kinds-of-executables.md
@@ -1,5 +1,5 @@
 ---
-title: "Knowing your Binary!"
+title: "Knowing Your Binary: Reading the file Command's ELF Output"
 layout: post
 date: 2016-06-15 00:00
 image:
@@ -10,7 +10,7 @@ tags:
 - Reverse Engineering
 - Tutorial
 blog: true
-description: "ELF, Mach-O, PE — decoding every word the file command throws at you"
+description: "Every token in that cryptic one-liner — bitness, architecture, ABI, dynamic linking, interpreter — explained one at a time."
 ---
 
 Ever thought why programs have different setup files for Windows, Mac and Linux. To give you a feel of it I'll tell you about the different kinds of formats the executable come in. I won't be going into the details but the next time you use the `file` command, you'll exactly know what you are looking at.

--- a/_posts/2016-07-04-owasp-zsc.md
+++ b/_posts/2016-07-04-owasp-zsc.md
@@ -11,7 +11,7 @@ tags:
 - OWASP
 - Shellcoding
 projects: true
-description: "Zeroday Cyber Research Shellcoder"
+description: "The Zeroday Cyber Research Shellcoder — an open-source shellcode generator and encoder I contributed to."
 ---
 
 <center>Zeroday Cyber Research Shellcoder by OWASP</center>

--- a/_posts/2016-11-03-did-i-execute.md
+++ b/_posts/2016-11-03-did-i-execute.md
@@ -1,5 +1,5 @@
 ---
-title: "Did I Execute?"
+title: "Did I Execute? Chaining Commands in the Shell"
 layout: post
 date: 2016-11-03 11:00
 image:
@@ -10,7 +10,7 @@ tags:
 - Shell
 - Tutorial
 blog: true
-description: "The subtle difference between ;, && and || that most terminal users get wrong"
+description: "The subtle difference between running commands in sequence, only on success, and only on failure — which trips up most terminal users."
 ---
 
 I'll be discussing about a small detail, about executing multiple commands on a terminal, which I realised most people don't know about.

--- a/_posts/2017-05-03-printing-emojis-on-terminal.md
+++ b/_posts/2017-05-03-printing-emojis-on-terminal.md
@@ -11,7 +11,7 @@ tags:
 - Shell
 - Tutorial
 blog: true
-description: "C++ code for printing emojis to terminal"
+description: "Outputting Unicode emoji from C and C++ with raw UTF-8 byte arrays and Unicode escapes — and the encoding details that matter."
 ---
 
 

--- a/_posts/2017-12-31-writeup-machine_learning.md
+++ b/_posts/2017-12-31-writeup-machine_learning.md
@@ -1,5 +1,5 @@
 ---
-title: "Machine Leaning - Coursera"
+title: "Machine Learning - Coursera"
 layout: post
 permalink: /writeups/machine_learning/
 date: 2017-12-31 19:11:48 +0530


### PR DESCRIPTION
## Why

These are old college-era posts I'm keeping around, but several gave Google and AI answer engines almost nothing to work with — clever-but-opaque headings, bare `Bandit Level N` titles that miss how people actually search, and thin or missing `<meta description>` tags. This is the first, cheapest tier of the full SEO/GEO audit: **front-matter only, no permalink or filename changes, so every URL stays stable.**

## What changed (32 posts, front-matter only)

**OverTheWire Bandit series (x20) — titles.** `Bandit Level N` -> `OverTheWire Bandit Level N -> N+1 Walkthrough`. Targets the query shapes people actually use (`overthewire bandit level 12`, `bandit 12 to 13 walkthrough`).

**Two opaque titles — added keywords.**
- `Did I Execute?` -> `Did I Execute? Chaining Commands in the Shell`
- `Knowing your Binary!` -> `Knowing Your Binary: Reading the file Command's ELF Output`

**Descriptions reworked to complement titles, not echo them.** Chirpy renders the `description` as a **visible subtitle directly under the H1**, so a description that repeats the title reads redundantly on the page. Fixed the overlaps:
- Bandit x20: dropped the repeated `Bandit Level N -> N+1:` prefix so each subtitle leads with the technique/tools (`xxd, gzip, bzip2, tar`, `nmap`, `netcat`, ...), which also adds long-tail tool keywords.
- Knowing Your Binary, OWASP ZSC, Infosec n00b L1-L3: dropped title-echoing prefixes; lead with the technique.
- Fixed a jekyll-seo-tag quirk that silently dropped a literal `||` from the `Did I Execute` description (reworded to plain words).

**Nine missing/thin meta descriptions filled in**: Checking out Stuff (was missing), SymPy, wptview, SymEngine, Infosec n00b Level 1/2/3 (were `n00b CTF N`), OWASP ZSC, Printing Emojis.

**Accuracy pass (rubber-duck review).** Verified every new title/description against the actual post body and corrected overclaims:
- Bandit 5 solve uses only a `find` size filter (not a non-executable flag).
- The "executables" post decodes one ELF `file` output line field-by-field — it does not explain Mach-O/PE — so the title/description were narrowed accordingly.
- SymEngine described as a standalone fast C++ CAS (not "powers SymPy's core").
- Printing Emojis: dropped the "platform-independent" claim; describe the raw UTF-8 / Unicode-escape approach instead.
- Checking out Stuff: removed "CTFs" (not in the post); Infosec L3: "Morse code" (not "cipher").

**Typo fix:** "Machine **Leaning**" -> "Machine **Learning**" in the ML Coursera post title.

## Deliberately not touched
- **No permalink/filename changes** — all URLs stable, no redirects needed.
- **Kept `BlogPosting` schema** (verified `mainEntityOfPage` still emits; `TechArticle` would silently drop it).
- **Project posts (SymPy / wptview / SymEngine)** — the project *name* recurs in an explanatory subtitle, which is defining (not echoing) and reads fine, so left as-is.
- **4 `redirect_to` posts left as-is** (Awesome Terminal Commands, ML Coursera, Graphics, HackInOut). Bringing "Awesome Terminal Commands" on-site as a real reference post is tracked as a follow-up.

> Note: the executables post also has a body-level factual error (it explains `LSB` as "Linux Standard Base" — in `file` output it means *Least Significant Byte* / little-endian). That is body content, out of scope for this front-matter-only PR; tracked as a follow-up.

## Before / After

Live `akashtrehan.com` (before) vs this branch, local production build (after). Both the visible **H1** and the **subtitle** are shown.

### OverTheWire Bandit (x20, level 12 shown)
| Before (live) | After (this branch) |
|---|---|
| ![before](https://github.com/CodeMaxx/CodeMaxx.github.io/releases/download/pr-assets/seo-bandit-before.png) | ![after](https://github.com/CodeMaxx/CodeMaxx.github.io/releases/download/pr-assets/seo-bandit-after.png) |

### "Did I Execute?"
| Before (live) | After (this branch) |
|---|---|
| ![before](https://github.com/CodeMaxx/CodeMaxx.github.io/releases/download/pr-assets/seo-didexec-before.png) | ![after](https://github.com/CodeMaxx/CodeMaxx.github.io/releases/download/pr-assets/seo-didexec-after.png) |

### "Knowing your Binary!"
| Before (live) | After (this branch) |
|---|---|
| ![before](https://github.com/CodeMaxx/CodeMaxx.github.io/releases/download/pr-assets/seo-binary-before.png) | ![after](https://github.com/CodeMaxx/CodeMaxx.github.io/releases/download/pr-assets/seo-binary-after.png) |

## Verification
- `JEKYLL_ENV=production` build succeeds with no warnings.
- Rendered `<title>`, `<meta name="description">`, `og:title`/`twitter:title`, JSON-LD `headline` + `BlogPosting`/`BreadcrumbList`, and the visible H1/subtitle all reflect the new titles and complementary descriptions; the `->` arrow is correctly UTF-8 encoded.
- Rubber-duck reviewed: no blocking issues; all 20 Bandit level numbers correct; YAML/encoding clean.