### PR TITLE
Fix LSB explanation and improve post heading hierarchy

### DIFF
--- a/_posts/2016-06-15-different-kinds-of-executables.md
+++ b/_posts/2016-06-15-different-kinds-of-executables.md
@@ -49,7 +49,19 @@ Lets go through each word one by one.
 
 ## LSB
 
-The Linux Standard Base (LSB) is a joint project by several Linux distributions under the organizational structure of the Linux Foundation to standardize the software system structure. This basically means that across different Linux based Operating Systems(Ubuntu, Fedora etc.), common rules would be used for compiling information into the binary(e.g. using some standard libraries for specific task, standardising the layout of the file system hierarchy etc.).
+`LSB` stands for `Least Significant Byte` and it tells us about the **endianness** of the binary, i.e. the order in which the bytes of a multi-byte number are stored in memory. `LSB`(also called **little-endian**) means the least significant byte is stored first.
+
+So a number like `0x12345678` would be stored in memory as:
+
+```
+78 56 34 12
+```
+
+This is the byte order used by `x86` and `x86-64` processors, which is exactly why we see it right next to `Intel 80386` in the output.
+
+### Other
+
+`MSB`(`Most Significant Byte`, or **big-endian**) is just the opposite - the most significant byte comes first, so `0x12345678` would be stored as `12 34 56 78`. You'll see this on architectures like `SPARC` and some older `MIPS`/`PowerPC` systems.
 
 ## Intel 80386
 

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -420,6 +420,20 @@ $tn-max: 1140px;
   font-size: 0.88rem;
 }
 
+/* ---------- Post heading hierarchy ---------- */
+/* Theme steps content headings only ~0.18rem apart, so an h3 barely reads as a
+   sub-section. Widen the steps. Scoped to .post-page so the search overlay and
+   sidebar (which also use .content) are untouched. */
+.post-page .content h2 {
+  font-size: 1.75rem;
+}
+.post-page .content h3 {
+  font-size: 1.4rem;
+}
+.post-page .content h4 {
+  font-size: 1.2rem;
+}
+
 /* ---------- Post reading measure ---------- */
 /* The default article column runs ~100 chars/line, which is too wide for
    comfortable prose. Constrain the article and its footer (Further Reading /


### PR DESCRIPTION
## Why

Two fixes, both surfaced while reviewing the *Knowing Your Binary* post:

1. **Wrong LSB explanation.** The `## LSB` section explained `LSB` as the *"Linux Standard Base"*. In `file`'s ELF output (`ELF 32-bit LSB executable, ...`), `LSB` is the ELF header's `EI_DATA` field (`ELFDATA2LSB`) and means **Least Significant Byte first** — i.e. **little-endian** byte order (`readelf -h` renders the same field as `Data: 2's complement, little endian`). Nothing to do with the Linux Standard Base project.
2. **Weak heading hierarchy (global).** The theme steps content headings only ~0.18rem apart (h2 1.54 / h3 1.36 / h4 1.18), so an `h3` barely reads as a sub-section of an `h2` in any post (the `### Other` sub-heading in this post was the tell).

## What changed

**LSB content** (`_posts/2016-06-15-different-kinds-of-executables.md`) — rewrote the `## LSB` section to explain endianness, with a byte-order example (`0x12345678` -> `78 56 34 12`) and an `MSB` / big-endian `### Other` counterpart. Written to match the post's voice.

**Heading hierarchy** (`assets/css/style.scss`) — widened the content heading scale to **h2 1.75 / h3 1.4 / h4 1.2rem**. Scoped to `.post-page .content` so only article bodies are affected.

## Scope / safety of the CSS change

The theme reuses `.content` in a few places, so the rule is scoped to `.post-page` (the article wrapper) to avoid leaking. Verified:
- **All page types checked** at 1280px — home (`.landing`), blog / write-ups / projects listings, about (`.about-content`, no headings), tags, archives, 404 — none affected.
- **Search overlay** reuses `.content` (result titles are `h2.panel-heading`); confirmed they keep the theme size (24.6px), not the enlarged 28px.
- **Sidebar** `ul.content` and **Trending Tags** heading unaffected.
- Rubber-duck reviewed (GPT-5.6 Sol): specificity/cascade correct, no theme `!important` or RFS override, scale is sensibly descending; both issues it raised (search leak + h4 too close to body text) are addressed in this final version.

## Before / After

Live `akashtrehan.com` (before: wrong "Linux Standard Base" text **and** the tight heading steps) vs this branch (after: corrected endianness explanation **and** the widened hierarchy — note `LSB`/`Intel 80386`/`SYSV` now clearly dominate the `Other` sub-heading):

| Before (live) | After (this branch) |
|---|---|
| ![before](https://github.com/CodeMaxx/CodeMaxx.github.io/releases/download/pr-assets/lsb-before.png) | ![after](https://github.com/CodeMaxx/CodeMaxx.github.io/releases/download/pr-assets/lsb-after.png) |

## Verification
- `JEKYLL_ENV=production` build succeeds with no warnings.
- Post headings compute to h2 28px / h3 22.4px; search result titles stay at the theme 24.6px.

Fixes BakerStreet-4k5.