### PR TITLE
Polish blog UX: sticky TOC, side panel, external de-dup, tag count

### DIFF
--- a/.htmlproofer.yaml
+++ b/.htmlproofer.yaml
@@ -18,6 +18,14 @@ ignore_urls:
   # Chirpy theme head/footer links (introduced by the theme, not post content):
   - /twitter\.com/                          # X/Twitter returns 404 to bots (JS-based)
   - /\bx\.com/                              # X/Twitter returns 404 to bots (JS-based)
+  # Post-sharing target hosts — share-intent URLs, not navigable content; they
+  # block GitHub Actions IPs or require login (Facebook/LinkedIn/Twitter share
+  # paths are already covered by the whole-domain rules above):
+  - /t\.me\/share/                          # Telegram share
+  - /reddit\.com\/submit/                   # Reddit share
+  - /news\.ycombinator\.com\/submitlink/    # Hacker News share
+  - /bsky\.app\/intent/                     # Bluesky share
+  - /whatsapp\.com\/send/                   # WhatsApp share
   - /fonts\.googleapis\.com/                # Preconnect hint; bare host 404s but font CSS is valid
   - /fonts\.gstatic\.com/                   # Preconnect hint; bare host 404s but fonts are valid
 

--- a/Rakefile
+++ b/Rakefile
@@ -13,6 +13,7 @@ task :test do
   options = {
     allow_hash_href: config['allow_hash_href'] || true,
     allow_missing_href: config['allow_missing_href'] || false,
+    ignore_empty_mailto: true,
     typhoeus: {
       headers: {
         "User-Agent" => "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",

--- a/_data/share.yml
+++ b/_data/share.yml
@@ -14,6 +14,26 @@ platforms:
     icon: "fab fa-linkedin"
     link: "https://www.linkedin.com/feed/?shareActive=true&shareUrl=URL"
 
+  - type: Bluesky
+    icon: "fa-brands fa-bluesky"
+    link: "https://bsky.app/intent/compose?text=TITLE%20URL"
+
+  - type: Reddit
+    icon: "fa-brands fa-reddit"
+    link: "https://www.reddit.com/submit?url=URL&title=TITLE"
+
+  - type: Hacker News
+    icon: "fa-brands fa-hacker-news"
+    link: "https://news.ycombinator.com/submitlink?u=URL&t=TITLE"
+
   - type: Telegram
-    icon: "fab fa-telegram"
+    icon: "fa-brands fa-telegram"
     link: "https://t.me/share/url?url=URL&text=TITLE"
+
+  - type: WhatsApp
+    icon: "fa-brands fa-whatsapp"
+    link: "https://api.whatsapp.com/send?text=TITLE%20URL"
+
+  - type: Email
+    icon: "fa-solid fa-envelope"
+    link: "mailto:?subject=TITLE&body=URL"

--- a/_includes/toc-autoscroll.html
+++ b/_includes/toc-autoscroll.html
@@ -1,0 +1,50 @@
+<!--
+  Auto-scroll the sticky Table of Contents so the active entry stays visible.
+
+  On long posts the TOC list is taller than its (viewport-capped) container and
+  scrolls internally. tocbot only toggles `.is-active-link`; it does not scroll
+  the list, so the current section's entry could sit out of view. This keeps the
+  active link scrolled into the TOC's own scroll box as you read.
+-->
+<script>
+  (function () {
+    function setup() {
+      var wrapper = document.getElementById('toc-wrapper');
+      var toc = document.getElementById('toc');
+      if (!wrapper || !toc) {
+        return;
+      }
+
+      function scrollActiveIntoView() {
+        var active = toc.querySelector('.is-active-link');
+        if (!active) {
+          return;
+        }
+        var heading = wrapper.querySelector('.panel-heading');
+        var headH = heading ? heading.offsetHeight : 0;
+        var wRect = wrapper.getBoundingClientRect();
+        var aRect = active.getBoundingClientRect();
+        var margin = 8;
+        if (aRect.top < wRect.top + headH) {
+          wrapper.scrollTop -= wRect.top + headH - aRect.top + margin;
+        } else if (aRect.bottom > wRect.bottom) {
+          wrapper.scrollTop += aRect.bottom - wRect.bottom + margin;
+        }
+      }
+
+      var observer = new MutationObserver(scrollActiveIntoView);
+      observer.observe(toc, {
+        subtree: true,
+        attributes: true,
+        attributeFilter: ['class']
+      });
+      scrollActiveIntoView();
+    }
+
+    if (document.readyState !== 'loading') {
+      setup();
+    } else {
+      document.addEventListener('DOMContentLoaded', setup);
+    }
+  })();
+</script>

--- a/_includes/update-list.html
+++ b/_includes/update-list.html
@@ -1,0 +1,35 @@
+<!--
+  Recent Posts — right-panel widget.
+
+  Local override of the Chirpy theme's "Recently Updated" widget. The theme
+  ordered by `last_modified_at` (git last-commit), which surfaced a wall of
+  identical "Updated" dates after bulk edits and carried no note of what
+  changed. Instead we surface the most recently *published* posts so readers
+  have fresh content to jump to. Keeps the same include name so the theme's
+  default layout picks it up without a layout override.
+-->
+
+{% assign MAX_SIZE = 5 %}
+{% assign recent = site.posts | where_exp: 'item', 'item.hidden != true' %}
+
+{% if recent.size > 0 %}
+  <section id="access-recent">
+    <h2 class="panel-heading">Recent Posts</h2>
+    <ul class="content list-unstyled ps-0 pb-1 ms-1 mt-2">
+      {% for post in recent limit: MAX_SIZE %}
+        {% if post.redirect_to %}
+          {% assign url = post.redirect_to %}
+        {% else %}
+          {% assign url = post.url | relative_url %}
+        {% endif %}
+        <li class="lh-lg">
+          <a
+            href="{{ url }}"
+            {%- if post.redirect_to %} target="_blank" rel="noopener noreferrer"{% endif -%}
+          ><span class="rp-title">{{ post.title }}</span>{% if post.redirect_to %}<i class="fas fa-arrow-up-right-from-square external-link-icon ms-1" aria-hidden="true"></i><span class="sr-only"> (opens in a new tab)</span>{% endif %}</a>
+        </li>
+      {% endfor %}
+    </ul>
+  </section>
+  <!-- #access-recent -->
+{% endif %}

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -130,8 +130,9 @@ refactor: true
               {% if post.redirect_to %}
                 <i
                   class="fas fa-arrow-up-right-from-square external-link-icon ms-1"
-                  title="Opens an external site"
+                  aria-hidden="true"
                 ></i>
+                <span class="sr-only"> (opens in a new tab)</span>
               {% endif %}
             </h1>
 
@@ -147,19 +148,15 @@ refactor: true
                   {% include datetime.html date=post.date lang=lang %}
                 </span>
 
-                <!-- reading time, or an explicit External marker for
-                     redirect_to posts (which have no local content) -->
-                {% if post.redirect_to %}
-                  <span class="meta-item meta-external">
-                    <i class="fas fa-arrow-up-right-from-square fa-fw me-1"></i>
-                    <span>External</span>
-                  </span>
-                {% else %}
+                <!-- reading time (external redirect_to posts have no local
+                     content, so no reading time; the title's external-link
+                     icon already signals that they leave the site) -->
+                {% unless post.redirect_to %}
                   <span class="meta-item">
                     <i class="far fa-clock fa-fw me-1"></i>
                     {% include read-time.html content=post.content prompt=true lang=lang %}
                   </span>
-                {% endif %}
+                {% endunless %}
 
                 <!-- points (CTF write-ups) -->
                 {% if post.points %}

--- a/_layouts/landing.html
+++ b/_layouts/landing.html
@@ -104,20 +104,18 @@ refactor: true
               <a href="{{ href }}" {% if post.redirect_to %}target="_blank" rel="noopener noreferrer"{% endif %}>
                 {{ post.title }}
                 {% if post.redirect_to %}
-                  <i class="fas fa-arrow-up-right-from-square external-link-icon"></i>
+                  <i class="fas fa-arrow-up-right-from-square external-link-icon" aria-hidden="true"></i>
+                  <span class="sr-only"> (opens in a new tab)</span>
                 {% endif %}
               </a>
             </h3>
 
             <div class="feature-meta">
               <span><i class="far fa-calendar fa-fw"></i>{% include datetime.html date=post.date lang=lang %}</span>
-              {% if post.redirect_to %}
-                <span class="feature-meta-sep">&middot;</span>
-                <span class="feature-meta-external"><i class="fas fa-arrow-up-right-from-square fa-fw"></i> External</span>
-              {% else %}
+              {% unless post.redirect_to %}
                 <span class="feature-meta-sep">&middot;</span>
                 <span>{% include read-time.html content=post.content prompt=true lang=lang %}</span>
-              {% endif %}
+              {% endunless %}
               {% if post.points %}
                 <span class="feature-meta-sep">&middot;</span>
                 <span><i class="fas fa-trophy fa-fw"></i>{{ post.points }} pts</span>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -6,6 +6,7 @@ tail_includes:
   - related-posts
 script_includes:
   - comment
+  - toc-autoscroll
 ---
 
 {% include lang.html %}
@@ -124,12 +125,11 @@ script_includes:
       </div>
     {% endif %}
 
-    <!-- tags + share on one row (stacks on mobile) -->
+    <!-- tags, then the share row on its own line below -->
     <div
       class="
         post-tail-bottom
-        d-flex flex-column flex-sm-row justify-content-between
-        align-items-start align-items-sm-center gap-3 mt-4 pb-2
+        d-flex flex-column align-items-start gap-3 mt-4 pb-2
       "
     >
       {% if page.tags.size > 0 %}

--- a/_layouts/tag.html
+++ b/_layouts/tag.html
@@ -16,11 +16,14 @@ panel_includes:
 
 <div id="page-tag" class="tag-page">
   <header class="tag-header">
-    <h1 class="tag-title">
-      <i class="fa fa-tag"></i>
-      <span>{{ page.title }}</span>
-      <span class="tag-count">{{ page.posts | size }}</span>
-    </h1>
+    <div class="tag-head">
+      <i class="fa fa-tag tag-head-icon" aria-hidden="true"></i>
+      <div>
+        <h1 class="tag-title">{{ page.title }}</h1>
+        {% assign tag_post_count = page.posts | size %}
+        <p class="listing-count">{{ tag_post_count }} post{% unless tag_post_count == 1 %}s{% endunless %}</p>
+      </div>
+    </div>
   </header>
   <ul class="tag-list content ps-0">
     {% for k in keyed %}

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -36,12 +36,6 @@
   color: var(--accent-1);
   vertical-align: 0.35em;
 }
-/* Explicit "External" marker that fills the read-time slot on redirect_to
-   posts (which have no local content, hence no reading time). */
-.meta-item.meta-external,
-.feature-meta-external {
-  color: var(--accent-1);
-}
 
 /* ============================================================
    Blue -> indigo accent tokens (BLACKBOX-style landing revamp)
@@ -239,27 +233,21 @@ $tn-max: 1140px;
 .tag-header {
   margin: 3rem 0 1.5rem;
 }
-.tag-title {
+.tag-head {
   display: flex;
   align-items: baseline;
-  flex-wrap: wrap;
-  gap: 0.6rem;
+  gap: 0.7rem;
+}
+.tag-head-icon {
+  color: var(--accent-1);
+  font-size: clamp(1.3rem, 2.2vw, 1.7rem);
+  flex-shrink: 0;
+}
+.tag-title {
   font-size: clamp(1.8rem, 3vw, 2.4rem);
   font-weight: 700;
   letter-spacing: -0.02em;
   margin: 0;
-}
-.tag-title i {
-  color: var(--accent-1);
-  font-size: 0.7em;
-}
-.tag-title .tag-count {
-  font-size: 0.85rem;
-  font-weight: 600;
-  color: var(--accent-1);
-  background: var(--accent-soft);
-  padding: 0.1rem 0.65rem;
-  border-radius: 999px;
 }
 .tag-list li > a {
   color: var(--heading-color) !important;
@@ -462,13 +450,14 @@ $tn-max: 1140px;
 .post-tail-bottom {
   align-items: flex-start;
 }
-@media (min-width: 576px) {
-  .post-tail-bottom {
-    align-items: center;
-  }
-  .post-tail-bottom .share-wrapper {
-    margin-inline-start: auto;
-  }
+/* The share row sits on its own line below the tags (there are enough share
+   targets that a side-by-side row crowded the tags); let the icons wrap on
+   very narrow screens. */
+.share-wrapper {
+  flex-wrap: wrap;
+}
+.share-icons {
+  flex-wrap: wrap;
 }
 .post-tags .post-tag-pill {
   border: 1px solid var(--accent-1);
@@ -594,10 +583,11 @@ div[class^='language-'] .code-header {
   padding-left: 0;
   padding-right: 0;
 }
-/* External-link badge in the archives / tag / related-posts listings. */
+/* External-link badge in the archives / tag / related-posts / recent-posts listings. */
 #archives .external-link-icon,
 .tag-list .external-link-icon,
-#related-posts .external-link-icon {
+#related-posts .external-link-icon,
+#access-recent .external-link-icon {
   font-size: 0.6em;
   color: var(--text-muted-color);
   vertical-align: 0.35em;
@@ -618,6 +608,87 @@ div[class^='language-'] .code-header {
 }
 #toc .toc-link:hover {
   color: var(--accent-2) !important;
+}
+
+/* The right-panel TOC is `position: sticky` but stuck at top:0 — i.e. behind
+   the 60px sticky top nav (z-index 1000) — so its "Contents" heading was
+   clipped whenever the article scrolled. Offset the sticky point just below the
+   nav and cap the height so long TOCs scroll internally instead of running off
+   the bottom of the viewport. */
+#toc-wrapper {
+  top: 4.5rem !important;
+  max-height: calc(100vh - 6rem);
+  overflow-y: auto;
+}
+/* Chirpy adds two left-sidebar-era "top cover" gradient masks over the TOC:
+   `#toc-wrapper::before` (a 48px sticky spacer that left a big gap above
+   "Contents") and the sibling `.toc-border-cover` (z-index 3, which overlaps
+   and visually fades the "Contents" heading near the top of the page). Our
+   opaque top nav already masks that area, so drop both. */
+.toc-border-cover,
+#toc-wrapper::before {
+  display: none !important;
+}
+/* The theme's panel headings use a faint label grey (#585858, ~3.5:1 on white)
+   that reads as "hidden". Use the crisp heading colour instead, and pin the
+   TOC "Contents" heading to the top of its scroll box with a solid background
+   so long TOC lists clip cleanly behind it as they auto-scroll. */
+#panel-wrapper .panel-heading {
+  color: var(--heading-color);
+}
+#toc-wrapper .panel-heading {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background: var(--main-bg);
+}
+
+/* Trending Tags panel pills: keep them muted/grey so they blend with the rest
+   of the (grey) sidebar — Recent Posts, headings, TOC — instead of standing out
+   as a block of blue. They light up accent-filled with white text on hover,
+   which also fixes the poor light-mode hover contrast the theme shipped. */
+#panel-wrapper .access .post-tag {
+  border: 1px solid var(--btn-border-color) !important;
+  color: var(--text-muted-color) !important;
+  background: transparent;
+  transition:
+    background 0.15s ease,
+    color 0.15s ease,
+    border-color 0.15s ease;
+}
+#panel-wrapper .access .post-tag:hover {
+  background: var(--accent-1) !important;
+  border-color: var(--accent-1) !important;
+  color: #fff !important;
+}
+
+/* Recent Posts side-widget links stay subtle (muted, no underline) like the
+   theme's original "Recently Updated" list, turning accent on hover — so they
+   don't compete with the accent Trending Tags pills below. */
+#access-recent a {
+  display: flex;
+  align-items: center;
+  color: inherit;
+  border-bottom: none;
+}
+#access-recent a:hover {
+  color: var(--accent-1);
+}
+#access-recent .rp-title {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+}
+#access-recent .external-link-icon {
+  flex-shrink: 0;
+}
+
+/* Even vertical spacing between the sidebar widgets: the theme puts 4rem
+   between the .access sections (Recent Posts -> Trending Tags) but only 2rem
+   before the TOC, so the gaps looked uneven. Make them both 2rem. */
+#panel-wrapper .access > section:not(:first-child) {
+  margin-top: 2rem;
 }
 
 /* Offset anchored headings for the sticky top nav (60px) so TOC / heading-anchor


### PR DESCRIPTION
A round of UX polish for the blog, from a walkthrough of the live site. Small, independent fixes plus a calmer sidebar and a nicer share row.

## 1. Sticky Table of Contents
Three fixes to the right-panel TOC:
- It was `position: sticky` at `top: 0`, i.e. behind the 60px top nav, so the "Contents" heading was clipped while scrolling — now offset just below the nav.
- Removed Chirpy's 48px sticky `::before` "cover" above the heading (a left-sidebar-era artifact) that left a big empty gap above "Contents", so it sits close to the top.
- On long posts the TOC now **auto-scrolls the active entry into view** so you always see where you are.

| Before | After |
|---|---|
| ![before](https://github.com/CodeMaxx/CodeMaxx.github.io/releases/download/pr-assets/ishika-before-toc.png) | ![after](https://github.com/CodeMaxx/CodeMaxx.github.io/releases/download/pr-assets/ishika-after-toc.png) |

## 2. Calmer right sidebar
"Recently Updated" (identical dates after bulk edits) is replaced with **Recent Posts** (most recently published, all post types), subtle muted links with an "opens in a new tab" cue for external posts. The **Trending Tags** pills are now muted/grey so they blend with the rest of the grey sidebar instead of a jarring block of blue — they fill accent with white text on hover (which also fixes the theme's poor light-mode hover contrast).

| Before | After |
|---|---|
| ![before](https://github.com/CodeMaxx/CodeMaxx.github.io/releases/download/pr-assets/ishika-before-panel.png) | ![after](https://github.com/CodeMaxx/CodeMaxx.github.io/releases/download/pr-assets/ishika-after-panel.png) |

## 3. Removed the duplicate "External" indicator
External (`redirect_to`) posts showed two leaves-the-site cues — an icon by the title **and** an "External" badge by the date. The title icon already conveys it, so the badge is gone.

| Before | After |
|---|---|
| ![before](https://github.com/CodeMaxx/CodeMaxx.github.io/releases/download/pr-assets/ishika-before-blog-external.png) | ![after](https://github.com/CodeMaxx/CodeMaxx.github.io/releases/download/pr-assets/ishika-after-blog-external.png) |

## 4. Single tag page: count reads "N posts"
The per-tag count was a pill that looked like a clickable button. It now reads "N posts" (matching the Blogs / Write-ups / Projects headers), keeping the tag icon with the count aligned under the tag name.

| Before | After |
|---|---|
| ![before](https://github.com/CodeMaxx/CodeMaxx.github.io/releases/download/pr-assets/ishika-before-tagcount.png) | ![after](https://github.com/CodeMaxx/CodeMaxx.github.io/releases/download/pr-assets/ishika-after-tagcount.png) |

## 5. More ways to share
Expanded the post share options — **X, Facebook, LinkedIn, Bluesky, Reddit, Hacker News, Telegram, WhatsApp, Email** (+ copy-link) — and moved the share row onto its own line below the tags so it no longer crowds them.

![share row](https://github.com/CodeMaxx/CodeMaxx.github.io/releases/download/pr-assets/ishika-share-row.png)

---

### Notes
- Verified with a local `JEKYLL_ENV=production` build in light + dark mode, and `rake test` (html-proofer) passes locally.
- "Recent Posts" is a local override of the theme's `update-list.html` (same include name so the default layout picks it up); it only renders on post pages.
- Share-intent hosts (Telegram/Reddit/Hacker News/Bluesky/WhatsApp) are added to the html-proofer ignore list — they're not navigable content and block CI IPs / require login, consistent with the already-ignored X/Facebook/LinkedIn share links.
