### PR TITLE
Blog a11y + polish: accessible tag hover, full-bleed nav, consistent toggle icons, category icon

### DIFF
--- a/_includes/topbar.html
+++ b/_includes/topbar.html
@@ -38,9 +38,9 @@
     <div class="tn-controls d-flex align-items-center ms-auto">
       <!-- Dark / light mode toggle (moved from sidebar) -->
       {% unless site.theme_mode == 'light' or site.theme_mode == 'dark' %}
-        {%- capture icon_system -%}<i class="fa-solid fa-display" data-theme-mode="system"></i>{%- endcapture -%}
+        {%- capture icon_system -%}<svg data-theme-mode="system" class="mode-ico" xmlns="http://www.w3.org/2000/svg" width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="20" height="14" x="2" y="3" rx="2"></rect><path d="M8 21h8"></path><path d="M12 17v4"></path></svg>{%- endcapture -%}
         {%- capture icon_light -%}<svg data-theme-mode="light" class="mode-ico" xmlns="http://www.w3.org/2000/svg" width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="4"></circle><path d="M12 2v2"></path><path d="M12 20v2"></path><path d="m4.93 4.93 1.41 1.41"></path><path d="m17.66 17.66 1.41 1.41"></path><path d="M2 12h2"></path><path d="M20 12h2"></path><path d="m6.34 17.66-1.41 1.41"></path><path d="m19.07 4.93-1.41 1.41"></path></svg>{%- endcapture -%}
-        {%- capture icon_dark -%}<i class="fa-regular fa-moon" data-theme-mode="dark"></i>{%- endcapture -%}
+        {%- capture icon_dark -%}<svg data-theme-mode="dark" class="mode-ico" xmlns="http://www.w3.org/2000/svg" width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z"></path></svg>{%- endcapture -%}
 
         <div class="btn-group dropdown tn-mode">
           <button

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -169,7 +169,7 @@ refactor: true
                 <!-- CTF challenge type (write-ups) -->
                 {% if post.ctf_category %}
                   <span class="meta-item">
-                    <i class="far fa-folder-open fa-fw me-1"></i>
+                    <i class="fas fa-puzzle-piece fa-fw me-1"></i>
                     <span class="categories">{{ post.ctf_category }}</span>
                   </span>
                 {% endif %}

--- a/_layouts/landing.html
+++ b/_layouts/landing.html
@@ -26,7 +26,7 @@ refactor: true
       </div>
 
       <div class="hero-follow">
-        <p class="hero-follow-label">Follow me on</p>
+        <p class="hero-follow-label">Connect with me</p>
         {% include social-icons.html extra_class="hero-socials" %}
       </div>
     </div>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -61,7 +61,7 @@ script_includes:
       {% endif %}
       {% if page.ctf_category %}
         <span class="phm-sep">&middot;</span>
-        <span><i class="far fa-folder-open fa-fw"></i>{{ page.ctf_category }}</span>
+        <span><i class="fas fa-puzzle-piece fa-fw"></i>{{ page.ctf_category }}</span>
       {% endif %}
     </div>
   </header>

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -45,6 +45,9 @@
   --accent-2: #4f3ff0; // indigo
   --accent-grad: linear-gradient(120deg, #1d7bf5 0%, #4f3ff0 100%);
   --accent-soft: rgba(79, 63, 240, 0.12);
+  /* Filled tag-pill hover: darker than --accent-1 so white text meets WCAG AA
+     (white on #1565c0 ~= 5.7:1; --accent-1 #1d7bf5 was only ~4:1). */
+  --tag-hover-bg: #1565c0;
 }
 
 html[data-bs-theme='dark'] {
@@ -52,6 +55,25 @@ html[data-bs-theme='dark'] {
   --accent-2: #7d6bff;
   --accent-grad: linear-gradient(120deg, #4aa2ff 0%, #7d6bff 100%);
   --accent-soft: rgba(125, 107, 255, 0.16);
+  --tag-hover-bg: #2668cc;
+}
+
+/* Reserve scrollbar space on both edges so the centered layout doesn't shift
+   left when the vertical scrollbar appears (the "more padding on the right"
+   Ishika noticed is the OS scrollbar, not an off-centre container). */
+html {
+  scrollbar-gutter: stable both-edges;
+}
+
+/* Theme-mode icons are matching thin-stroke inline SVGs (sun / moon / monitor)
+   so they share one visual style. Keep them aligned and give a little breathing
+   room between the icon and its label in the dropdown menu. */
+.mode-ico {
+  flex-shrink: 0;
+  vertical-align: -0.18em;
+}
+.tn-mode .dropdown-item > .mode-ico {
+  margin-inline-end: 0.55rem;
 }
 
 /* Links + tag pills pick up the accent site-wide. */
@@ -77,9 +99,13 @@ $tn-max: 1140px;
 }
 #main-wrapper {
   margin-left: 0 !important;
+  overflow-x: clip;
 }
 
-/* Full-width sticky nav with a bottom hairline. */
+/* Sticky nav. The visible background + hairline are painted by a full-viewport
+   -width ::before so that, as the page scrolls, the hero's blue glow disappears
+   cleanly behind the nav across the whole width instead of bleeding up through
+   the side margins beside the (container-width) bar. */
 #topbar-wrapper {
   position: sticky;
   top: 0;
@@ -87,9 +113,20 @@ $tn-max: 1140px;
   width: 100%;
   height: 60px;
   z-index: 1000;
+  background-color: transparent;
+  box-shadow: none;
+}
+#topbar-wrapper::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 100vw;
+  height: 100%;
+  z-index: -1;
   background-color: var(--main-bg);
   border-bottom: 1px solid var(--main-border-color, rgba(0, 0, 0, 0.075));
-  box-shadow: none;
 }
 
 #topbar {
@@ -161,9 +198,8 @@ $tn-max: 1140px;
 
 /* Show only the icon for the active mode (the base theme scopes this to
    #sidebar; re-scope it to the top-nav toggle so it reads as one clean
-   button). Rules are tag-agnostic so the light icon can be an inline SVG. */
-.tn-mode #mode-toggle > i,
-.tn-mode #mode-toggle > svg {
+   button). */
+.tn-mode #mode-toggle > .mode-ico {
   display: none;
 }
 /* The trigger always shows the icon for the currently-resolved appearance
@@ -180,16 +216,6 @@ $tn-max: 1140px;
   > [data-theme-mode='light'] {
   display: block;
 }
-/* Inline SVG icon (light mode): keep it aligned in the button and spaced
-   from the label inside the dropdown menu. */
-.mode-ico {
-  flex-shrink: 0;
-  vertical-align: -0.18em;
-}
-.tn-mode .dropdown-item > .mode-ico {
-  margin-right: 0.5rem;
-}
-
 /* The hamburger is non-functional now (nav links are always visible); hide it.
    The theme's `#sidebar-trigger` id beats a class, so match the id + !important. */
 #topbar #sidebar-trigger.tn-hamburger {
@@ -274,13 +300,13 @@ $tn-max: 1140px;
     color 0.15s ease;
 }
 #all-tags .post-tag:hover {
-  background: var(--accent-1);
+  background: var(--tag-hover-bg);
   color: #fff !important;
 }
 #all-tags .post-tag.tag-current {
-  background: var(--accent-1);
+  background: var(--tag-hover-bg);
   color: #fff !important;
-  border-color: var(--accent-1);
+  border-color: var(--tag-hover-bg) !important;
 }
 
 /* ---------- About page ---------- */
@@ -468,7 +494,7 @@ $tn-max: 1140px;
   transition: background 0.15s ease, color 0.15s ease;
 }
 .post-tags .post-tag-pill:hover {
-  background: var(--accent-1);
+  background: var(--tag-hover-bg);
   color: #fff !important;
 }
 
@@ -552,12 +578,16 @@ div[class^='language-'] .code-header {
 }
 #tags .tag:hover,
 #tags .tag:focus-visible {
-  background: var(--accent-1);
-  color: #fff;
+  background: var(--tag-hover-bg);
+  color: #fff !important;
 }
 #tags .tag span {
   color: inherit !important;
   opacity: 0.7;
+}
+#tags .tag:hover span,
+#tags .tag:focus-visible span {
+  opacity: 1;
 }
 @media (max-width: 991px) {
   #tags {
@@ -657,8 +687,8 @@ div[class^='language-'] .code-header {
     border-color 0.15s ease;
 }
 #panel-wrapper .access .post-tag:hover {
-  background: var(--accent-1) !important;
-  border-color: var(--accent-1) !important;
+  background: var(--tag-hover-bg) !important;
+  border-color: var(--tag-hover-bg) !important;
   color: #fff !important;
 }
 
@@ -1372,7 +1402,8 @@ div[class^='language-'] .code-header {
     transition: background 0.15s ease, color 0.15s ease;
   }
   .feature-tag:hover {
-    background: var(--accent-1);
+    background: var(--tag-hover-bg);
+    border-color: var(--tag-hover-bg);
     color: #fff !important;
   }
 


### PR DESCRIPTION
A second round of blog polish from the ongoing design review — accessibility, a cleaner scroll experience, and a couple of icon fixes.

## 1. Accessible tag-pill hover (WCAG AA)
On the Tags page, hovered pills were showing **orange text** — the theme's `.content a:hover` rule (orange, `!important`) was overriding the tag-hover colour. And elsewhere, white text on the bright accent (`#1d7bf5`) was only ~4:1, failing WCAG AA. Fix: a darker `--tag-hover-bg` (`#1565c0` light / `#2668cc` dark, ~5.5:1) with white text forced across **every** tag-pill hover (Tags page, All Tags panel, Trending Tags, post-footer pills, landing feature tags) plus the active-tag state; the count stays fully legible.

| Before (orange text, ~4:1) | After (white, ~5.5:1) |
|---|---|
| ![before](https://github.com/CodeMaxx/CodeMaxx.github.io/releases/download/pr-assets/r2-before-taghover.png) | ![after](https://github.com/CodeMaxx/CodeMaxx.github.io/releases/download/pr-assets/r2-after-taghover.png) |

## 2. Nav no longer lets the hero glow bleed through
On the landing page, as you scrolled, the blue glow around the hero photo bled up through the side margins beside the (container-width) sticky nav — it looked like the blue was leaking past the header. The nav background + hairline are now painted by a full-viewport-width layer, so the glow disappears cleanly behind the nav across the whole width. (No horizontal-scroll side effect; `overflow-x: clip` guards it.)

| Before (blue bleeding beside the nav) | After (clean) |
|---|---|
| ![before](https://github.com/CodeMaxx/CodeMaxx.github.io/releases/download/pr-assets/r2-before-nav.png) | ![after](https://github.com/CodeMaxx/CodeMaxx.github.io/releases/download/pr-assets/r2-after-nav.png) |

## 3. Consistent theme-mode toggle icons
The light (sun) icon was the only hand-rolled inline `<svg>`, clashing with the Font Awesome moon/monitor beside it, and the icon-to-label spacing was uneven. All three are now matching thin-stroke inline SVGs (sun / moon / monitor) in one consistent style, with even spacing.

| Before (mismatched sun, uneven gaps) | After (matching thin-stroke SVGs) |
|---|---|
| ![before](https://github.com/CodeMaxx/CodeMaxx.github.io/releases/download/pr-assets/r2-before-toggle.png) | ![after](https://github.com/CodeMaxx/CodeMaxx.github.io/releases/download/pr-assets/r2-after-toggle.png) |

## 4. Write-up category icon: folder → puzzle-piece
The folder-open icon read like a file folder rather than a challenge type. Switched to a puzzle-piece, which reads as "a challenge to solve" and pairs naturally with the category name (e.g. "🧩 Pwn").

| Before | After |
|---|---|
| ![before](https://github.com/CodeMaxx/CodeMaxx.github.io/releases/download/pr-assets/r2-before-category.png) | ![after](https://github.com/CodeMaxx/CodeMaxx.github.io/releases/download/pr-assets/r2-after-category.png) |

## 5. Smaller landing tweaks
- Hero social label: **"Follow me on" → "Connect with me"** (visible in the toggle screenshots above).
- Reserve scrollbar space on both edges (`scrollbar-gutter`) so the centered layout doesn't shift left when the page scrollbar appears.

---

### Notes
- Verified with a local `JEKYLL_ENV=production` build in light + dark mode, scrolled through long posts, and checked there's no horizontal overflow and that the sticky nav / TOC still stick.
- Tag-hover contrast ratios computed against the new token: white on `#1565c0` = 5.75:1, on `#2668cc` = 5.34:1 (both pass AA); the old accent was 4.04:1.


