### PR TITLE
Center full-width pages on ultra-wide (>=1650px) screens

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -249,6 +249,22 @@ $tn-max: 1140px;
   flex: 0 0 100%;
   max-width: 100%;
 }
+/* At >=1650px the theme adds `padding-right: 4.5rem` to `main.col-12` (and
+   #tail-wrapper) to clear the right panel, while the left padding stays at
+   1.5rem. On these full-width pages the panel is hidden, so that extra right
+   padding pushes the column ~48px off-centre. Reset the right padding to match
+   the left so the content stays centred. */
+@media all and (min-width: 1650px) {
+  #main-wrapper {
+    &:has(.landing), &:has(.listing), &:has(.about),
+    &:has(.notfound), &:has(#tags), &:has(#archives) {
+      > .container > .row > main,
+      #tail-wrapper {
+        padding-right: 1.5rem !important;
+      }
+    }
+  }
+}
 
 /* ---------- Tag pages ---------- */
 /* Keep the right panel, but replace the theme's Trending Tags / Recently


### PR DESCRIPTION
On wide screens (>=1650px) the home page — and the other full-width pages — weren't centred: there was noticeably more empty space on the right than the left. Spotted in a design-review pass.

## Why
Chirpy's default layout is two columns (article + right TOC / trending panel). To keep the article clear of that panel, the theme adds extra right padding to the main column at >=1650px:

```css
@media (min-width: 1650px){ main.col-12 { padding-right: 4.5rem !important } }
```

The left padding stays at the normal `1.5rem` gutter, so it's **24px left / 72px right** — balanced only because the side panel fills that extra 48px.

On the full-width pages (home / listings / about / 404 / tags / archives) that panel is hidden, so the reserved 48px had nothing to fill it and pushed the whole column ~48px left of centre. `#tail-wrapper` had the same issue.

## Fix
Reset `padding-right` back to the symmetric `1.5rem` gutter (main column **and** `#tail-wrapper`) on those pages, scoped to the same `>=1650px` breakpoint. It overrides the theme rule via higher specificity (the `#main-wrapper:has(...)` chain).

Why `1.5rem` is the correct value, not a guess: `padding-left` is a **constant `1.5rem` (24px) for every width >=768px** (measured 768 -> 3440px), so this simply makes right == left. Below 768px my rule doesn't apply, so mobile (a symmetric 12/12) is untouched. The asymmetry appears at *exactly* >=1650px, which is *exactly* where the override is scoped.

## Before / After
Home page @ 1920px, with guides added for clarity — red bands = empty side gaps, green line = true viewport centre.

| Before (live site) | After (this branch) |
|---|---|
| ![before](https://github.com/CodeMaxx/CodeMaxx.github.io/releases/download/pr-assets/center-before.png) | ![after](https://github.com/CodeMaxx/CodeMaxx.github.io/releases/download/pr-assets/center-after.png) |

Left / right gap: **396 / 444px (48px off-centre)** → **420 / 420px (centred)**.

---
- Verified with a local `JEKYLL_ENV=production` build.
- Gaps measured with Playwright across 767 -> 3440px; only >=1650px viewports change, narrower screens are byte-for-byte unchanged.
