### PR TITLE
Remove redundant "See other Blog posts" footer from legacy posts

### DIFF
--- a/_posts/2016-06-15-different-kinds-of-executables.md
+++ b/_posts/2016-06-15-different-kinds-of-executables.md
@@ -105,5 +105,3 @@ Cheers!
 
 > If you are an Infosec person, don't forget to checkout my [CTF Write-ups](/writeups/)
 {: .prompt-tip }
-
-[See other Blog posts](/blog/)

--- a/_posts/2017-08-25-csec-binary-exploitation-1.md
+++ b/_posts/2017-08-25-csec-binary-exploitation-1.md
@@ -32,5 +32,3 @@ Cheers!
 
 > If you are an Infosec person, don't forget to checkout my [CTF Write-ups](/writeups/).
 {: .prompt-tip }
-
-[See other Blog posts](/blog/)

--- a/_posts/2017-10-18-Ubisoft-GameJam-Winners.md
+++ b/_posts/2017-10-18-Ubisoft-GameJam-Winners.md
@@ -45,5 +45,3 @@ Cheers!
 
 > If you are an Infosec person, don't forget to checkout my [CTF Write-ups](/writeups/).
 {: .prompt-tip }
-
-[See other Blog posts](/blog/)

--- a/_posts/2017-11-08-csec-binary-exploitation-2.md
+++ b/_posts/2017-11-08-csec-binary-exploitation-2.md
@@ -31,5 +31,3 @@ Cheers!
 
 > If you are an Infosec person, don't forget to checkout my [CTF Write-ups](/writeups/).
 {: .prompt-tip }
-
-[See other Blog posts](/blog/)

--- a/_posts/2017-12-23-right-way-to-use-sublime-text.md
+++ b/_posts/2017-12-23-right-way-to-use-sublime-text.md
@@ -50,5 +50,3 @@ Cheers!
 
 > If you are an Infosec person, don't forget to checkout my [CTF Write-ups](/writeups/).
 {: .prompt-tip }
-
-[See other Blog posts](/blog/)


### PR DESCRIPTION
## What & why

Five legacy posts ended with a hand-written **`[See other Blog posts](/blog/)`** link — a leftover from before the site moved to the Chirpy theme. The theme now renders an automatic **Further Reading** related-posts section at the foot of every post, plus a persistent top-nav **Blog** link, so the manual footer is redundant and just adds visual noise below the content.

This removes it from the 5 posts that still carried it.

## Changes
Deleted the trailing `[See other Blog posts](/blog/)` line (and its preceding blank line) from:
- `2016-06-15-different-kinds-of-executables.md`
- `2017-08-25-csec-binary-exploitation-1.md`
- `2017-10-18-Ubisoft-GameJam-Winners.md`
- `2017-11-08-csec-binary-exploitation-2.md`
- `2017-12-23-right-way-to-use-sublime-text.md`

## Before / After

**Before** (production) — redundant "See other Blog posts" link between the tip callout and the tags/Further Reading:

![before](https://raw.githubusercontent.com/CodeMaxx/CodeMaxx.github.io/2fe415246ccbf772359ddf62ca69954aac81461c/before.png)

**After** (local build) — the callout flows straight into tags → Further Reading:

![after](https://raw.githubusercontent.com/CodeMaxx/CodeMaxx.github.io/2fe415246ccbf772359ddf62ca69954aac81461c/after.png)
