### PR TITLE
Normalize desktop listing card heights to a fixed band

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -847,17 +847,12 @@ div[class^='language-'] .code-header {
   opacity: 0.92;
 }
 @media (min-width: 768px) {
+  /* Match the 15:8 ratio the listing images are cut to, so every card is the
+     same height and the wide images show as designed. */
   #post-list .post-preview .card-media {
-    aspect-ratio: auto;
+    aspect-ratio: 15 / 8;
     min-height: 100%;
     border-radius: 0 12px 12px 0;
-  }
-
-  /* Imageless posts use the placeholder (no intrinsic height); give it the
-     cover ratio so its card matches the image cards instead of collapsing. */
-  #post-list .post-preview .card-media:has(.card-media-placeholder) {
-    height: auto;
-    aspect-ratio: 15 / 8;
   }
 }
 


### PR DESCRIPTION
## What & why

Cards in the **Blog**, **Write-ups**, and **Projects** listings rendered at visibly uneven heights, so the vertical list looked ragged as you scrolled.

The cause was on the desktop card image: it used `aspect-ratio: auto`, so each card's height tracked *its image's* natural aspect ratio. Images of different shapes → cards of different heights.

## The fix

Pin the desktop card media to `aspect-ratio: 15 / 8` — the ratio the listing `*-wide` images are already cut to — so the media is a consistent height and the wide images show as designed (`object-fit: cover` barely crops). A single `.card-media` selector now covers image and placeholder cards alike (no `:has()` needed).

Cards are uniform on normal desktop widths; `min-height: 100%` still lets a body grow its card gracefully at narrow small-laptop widths (768–1024px), where the skinny text column wraps taller than the short image. **Mobile (`<768px`) is untouched** and keeps its full-width `16/9` cover.

## Verification

Local production build, checked with Playwright across `/blog/` (13 cards), `/writeups/` (36) and `/projects/` (8) in light and dark:

- **≥1200px: every card uniform (~236–238px);** placeholder cards match.
- 768–1024px: ~30px height variance (body-driven, degrades gracefully).
- Mobile unchanged (`16/9`, full-width).

## Before / After

Blog listing at 1280px.

| | Before | After |
|---|---|---|
| **Light** | ![before light](https://github.com/CodeMaxx/CodeMaxx.github.io/releases/download/pr-assets/af2-59-cards-before-light.png) | ![after light](https://github.com/CodeMaxx/CodeMaxx.github.io/releases/download/pr-assets/af2-59-cards-after-light.png) |
| **Dark** | ![before dark](https://github.com/CodeMaxx/CodeMaxx.github.io/releases/download/pr-assets/af2-59-cards-before-dark.png) | ![after dark](https://github.com/CodeMaxx/CodeMaxx.github.io/releases/download/pr-assets/af2-59-cards-after-dark.png) |
