### PR TITLE
Make legacy YouTube embeds responsive and accessible

### DIFF
--- a/_includes/embed/youtube.html
+++ b/_includes/embed/youtube.html
@@ -1,0 +1,9 @@
+<iframe
+  class="embed-video"
+  loading="lazy"
+  src="https://www.youtube.com/embed/{{ include.id }}"
+  title="{{ include.title | default: 'YouTube video player' | escape }}"
+  frameborder="0"
+  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+  allowfullscreen
+></iframe>

--- a/_posts/2017-08-25-csec-binary-exploitation-1.md
+++ b/_posts/2017-08-25-csec-binary-exploitation-1.md
@@ -22,7 +22,7 @@ Although the school year remains very buzy, I try to give as much time as possib
 
 Presenting the first video from the series (This is my debut video; go easy on me :stuck_out_tongue_winking_eye:) -
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/wOJl6N5oiQQ?ecver=1" frameborder="0" allowfullscreen></iframe>
+{% include embed/youtube.html id='wOJl6N5oiQQ' title='CSec Binary Exploitation vodcast, Episode 1' %}
 
 Liked it ??? Didn't like it ????? Let me know!
 

--- a/_posts/2017-10-18-Ubisoft-GameJam-Winners.md
+++ b/_posts/2017-10-18-Ubisoft-GameJam-Winners.md
@@ -35,7 +35,7 @@ After two days of coding, free food, hot chocolate and some great mentoring from
 
 Here's an aftermovie of the hackathon by Ubisoft:
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/cP-jsgug0FU" frameborder="0" gesture="media" allow="encrypted-media" allowfullscreen></iframe>
+{% include embed/youtube.html id='cP-jsgug0FU' title='Ubisoft GameJam 2017 aftermovie' %}
 
 The code for our game is open source and available [here](https://github.com/Ferozepurwale/Flood-League).
 

--- a/_posts/2017-11-08-csec-binary-exploitation-2.md
+++ b/_posts/2017-11-08-csec-binary-exploitation-2.md
@@ -22,7 +22,7 @@ In this one I talk about some more advanced exploitation techniques, mitigation 
 Don't miss the demo at the end!
 
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/hIIHNUiyw4A" frameborder="0" allowfullscreen></iframe>
+{% include embed/youtube.html id='hIIHNUiyw4A' title='CSec Binary Exploitation vodcast, Episode 2' %}
 
 
 Constructive criticism is much appreciated.


### PR DESCRIPTION
## Problem

The three video posts (**Ubisoft GameJam**, **CSec Binary Exploitation 1 & 2**) embedded a raw fixed-size iframe:

```html
<iframe width="560" height="315" src="https://www.youtube.com/embed/..." ...></iframe>
```

This caused three issues:

- **Mobile clipping** — at 390px the 560px iframe overflowed the 328px content column (~232px, ~35%). The parent hides overflow, so the right side was unreachable.
- **Desktop whitespace** — in the ~632px reading column the fixed 560px video left awkward right-side whitespace.
- **No accessible name** — the iframe had no `title` (fails WCAG 4.1.2 / axe `frame-title`).

## Fix

- Add a local override `_includes/embed/youtube.html` (the repo already overrides several gem includes). It matches Chirpy 7.6.0's include — responsive `.embed-video` wrapper (`width:100%; aspect-ratio:16/9`) + `loading="lazy"` — but makes the `title` parameterizable (escaped, with the theme's generic fallback).
- Replace the three raw iframes with `{% include embed/youtube.html id='...' title='...' %}`, each given a descriptive title.

## Verification

Production build + Playwright:
- Desktop 1440px: iframe fills `.content` exactly (0px gaps), 16:9.
- Mobile 390px: 328px wide, no horizontal overflow, no clipping.
- axe `frame-title`: **0 violations**.
- Light + dark mode both correct.

## Before / After

### Desktop (~1440px)
| Before (fixed 560px, right whitespace) | After (fills column) |
| --- | --- |
| ![before desktop](https://github.com/CodeMaxx/CodeMaxx.github.io/releases/download/pr-assets/af69-before-desktop.png) | ![after desktop](https://github.com/CodeMaxx/CodeMaxx.github.io/releases/download/pr-assets/af69-after-desktop.png) |

### Mobile (390px)
| Before (clipped ~35%) | After (fits full width) |
| --- | --- |
| ![before mobile](https://github.com/CodeMaxx/CodeMaxx.github.io/releases/download/pr-assets/af69-before-mobile.png) | ![after mobile](https://github.com/CodeMaxx/CodeMaxx.github.io/releases/download/pr-assets/af69-after-mobile.png) |

Closes af2.69.
