### PR TITLE
Show all live-search matches instead of capping at 10

### DIFF
--- a/_includes/search-loader.html
+++ b/_includes/search-loader.html
@@ -25,6 +25,7 @@
       searchInput: document.getElementById('search-input'),
       resultsContainer: document.getElementById('search-results'),
       json: '{{ '/assets/js/data/search.json' | relative_url }}',
+      limit: {{ site.posts | size }},
       searchResultTemplate: '{{ result_elem | strip_newlines }}',
       noResultsText: '{{ not_found }}',
       templateMiddleware: function(prop, value, template) {


### PR DESCRIPTION
## What

Live search (simple-jekyll-search) previously capped results at the library default of **10**, with no total count or "more results" indicator. Queries matching more than 10 posts were silently truncated.

Concrete symptom: searching **"bandit"** matched ~20 walkthroughs but only 10 rendered (and non-contiguously), so several Bandit levels were undiscoverable via search.

## Fix

Add a single `limit` option to the `SimpleJekyllSearch` config in `_includes/search-loader.html`, set to the size of the search index:

```
limit: {{ site.posts | size }},
```

`search.json` is generated by iterating `site.posts`, so `site.posts | size` is exactly the number of indexed entries. It's computed at build time (renders to `limit: 57` today) and grows with the blog, so there's no magic number and no future truncation. Showing all matches satisfies the acceptance criterion ("either shows all or clearly indicates truncation").

## Verification

- Production `JEKYLL_ENV=production` build + Playwright.
- Searching "bandit": result count went from **10 → 20** (all levels 0–19 now appear, including the previously-missing 0–4 and 10–14).
- Results render in the scrollable main content region; verified in light + dark mode.
- Rubber-duck review: no blocking issues.

## Before / After

Full-page search results for the query "bandit".

| | Before (10 results, truncated) | After (all 20 results) |
|---|---|---|
| **Light** | ![before light](https://github.com/CodeMaxx/CodeMaxx.github.io/releases/download/pr-assets/af2-70-before-light.png) | ![after light](https://github.com/CodeMaxx/CodeMaxx.github.io/releases/download/pr-assets/af2-70-after-light.png) |
| **Dark** | ![before dark](https://github.com/CodeMaxx/CodeMaxx.github.io/releases/download/pr-assets/af2-70-before-dark.png) | ![after dark](https://github.com/CodeMaxx/CodeMaxx.github.io/releases/download/pr-assets/af2-70-after-dark.png) |

Closes af2.70.
