### PR TITLE
Add skip link, label icon-only controls, and name a11y landmarks

### DIFF
--- a/_includes/refactor-content.html
+++ b/_includes/refactor-content.html
@@ -237,7 +237,7 @@
         | append: '<button aria-label="copy" data-title-succeed="'
         | append: site.data.locales[include.lang].post.button.copy_code.succeed
         | append: '"><i class="far fa-clipboard"></i></button></div>'
-        | append: '<div class="highlight"><code>'
+        | append: '<div class="highlight" tabindex="0"><code>'
       %}
     {% endif %}
   {% endfor %}
@@ -267,7 +267,7 @@
       {% assign id = snippet | split: '"' | first %}
       {% assign anchor = '<a href="#'
         | append: id
-        | append: '" class="anchor text-muted"><i class="fas fa-hashtag"></i></a>'
+        | append: '" class="anchor text-muted" aria-label="Permalink to this section"><i class="fas fa-hashtag" aria-hidden="true"></i></a>'
       %}
 
       {% assign left = snippet | split: mark_end | first %}

--- a/_includes/related-posts.html
+++ b/_includes/related-posts.html
@@ -74,7 +74,7 @@
     <h3 class="mb-4" id="related-label">
       {{- site.data.locales[include.lang].post.relate_posts -}}
     </h3>
-    <nav class="row row-cols-1 row-cols-md-2 g-4 mb-4">
+    <nav class="row row-cols-1 row-cols-md-2 g-4 mb-4" aria-labelledby="related-label">
       {% for post in relate_posts %}
         <article class="col">
           <a

--- a/_includes/search-results.html
+++ b/_includes/search-results.html
@@ -1,0 +1,11 @@
+<!-- The Search results -->
+
+<div id="search-result-wrapper" class="d-flex justify-content-center d-none">
+  <section class="col-11 content" aria-labelledby="search-results-heading">
+    <h1 id="search-results-heading" class="sr-only">Search results</h1>
+    <div id="search-hints">
+      {% include_cached trending-tags.html lang=include.lang %}
+    </div>
+    <div id="search-results" class="d-flex flex-wrap justify-content-center text-muted mt-3"></div>
+  </section>
+</div>

--- a/_includes/toc.html
+++ b/_includes/toc.html
@@ -1,0 +1,11 @@
+{% include toc-status.html %}
+
+{% if enable_toc %}
+  <div class="toc-border-cover z-3"></div>
+  <section id="toc-wrapper" class="invisible position-sticky ps-0 pe-4 pb-4">
+    <h2 id="toc-heading" class="panel-heading ps-3 pb-2 mb-0">
+      {{- site.data.locales[include.lang].panel.toc -}}
+    </h2>
+    <nav id="toc" aria-labelledby="toc-heading"></nav>
+  </section>
+{% endif %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,0 +1,99 @@
+---
+layout: compress
+---
+
+<!doctype html>
+
+{% include origin-type.html %}
+
+{% include lang.html %}
+
+<!-- `site.alt_lang` can specify a language different from the UI -->
+<html
+  lang="{{ page.lang | default: site.alt_lang | default: site.lang }}"
+  {%- if site.theme_mode == 'light' or site.theme_mode == 'dark' -%}
+    data-bs-theme="{{ site.theme_mode }}"
+  {%- endif -%}
+>
+  {% include head.html lang=lang %}
+
+  <body>
+    <a class="skip-link" href="#main-content">Skip to main content</a>
+
+    {% include sidebar.html lang=lang %}
+
+    <div id="main-wrapper" class="d-flex justify-content-center">
+      <div class="container d-flex flex-column px-xxl-5">
+        {% include topbar.html lang=lang %}
+
+        <div class="row flex-grow-1">
+          <main
+            id="main-content"
+            tabindex="-1"
+            aria-label="Main Content"
+            class="col-12 col-lg-11 col-xl-9 px-md-4"
+          >
+            {% if layout.layout == 'default' %}
+              {% include refactor-content.html content=content lang=lang %}
+            {% else %}
+              {{ content }}
+            {% endif %}
+          </main>
+
+          <!-- panel -->
+          <aside aria-label="Panel" id="panel-wrapper" class="col-xl-3 ps-2 text-muted">
+            <div class="access">
+              {% include_cached update-list.html lang=lang %}
+              {% include_cached trending-tags.html lang=lang %}
+            </div>
+
+            {% for _include in layout.panel_includes %}
+              {% assign _include_path = _include | append: '.html' %}
+              {% include {{ _include_path }} lang=lang %}
+            {% endfor %}
+          </aside>
+        </div>
+
+        <div class="row">
+          <!-- tail -->
+          <div id="tail-wrapper" class="col-12 col-lg-11 col-xl-9 px-md-4">
+            {% for _include in layout.tail_includes %}
+              {% assign _include_path = _include | append: '.html' %}
+              {% include {{ _include_path }} lang=lang %}
+            {% endfor %}
+
+            {% include_cached footer.html lang=lang %}
+          </div>
+        </div>
+
+        {% include_cached search-results.html lang=lang %}
+      </div>
+
+      <aside aria-label="Scroll to Top">
+        <button
+          id="back-to-top"
+          type="button"
+          class="btn btn-lg btn-box-shadow"
+          aria-label="Back to top"
+        >
+          <i class="fas fa-angle-up"></i>
+        </button>
+      </aside>
+    </div>
+
+    <div id="mask" class="d-none position-fixed w-100 h-100 z-1"></div>
+
+    {% if site.pwa.enabled %}
+      {% include_cached notification.html lang=lang %}
+    {% endif %}
+
+    <!-- Embedded scripts -->
+
+    {% for _include in layout.script_includes %}
+      {% assign _include_path = _include | append: '.html' %}
+      {% include {{ _include_path }} %}
+    {% endfor %}
+
+    {% include_cached search-loader.html lang=lang %}
+  </body>
+</html>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -80,7 +80,7 @@ script_includes:
   {% if enable_toc %}
     <div id="toc-bar" class="d-flex align-items-center justify-content-between invisible">
       <span class="label text-truncate">{{ page.title }}</span>
-      <button type="button" class="toc-trigger btn me-1">
+      <button type="button" class="toc-trigger btn me-1" aria-label="Table of contents">
         <i class="fa-solid fa-list-ul fa-fw"></i>
       </button>
     </div>

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -560,6 +560,12 @@ div[class^='language-'] .code-header {
 .code-header button:not([timeout]):hover i {
   color: var(--accent-1) !important;
 }
+/* `.highlight` gets tabindex=0 (refactor-content.html) so wide code scrolls via
+   keyboard; show a focus ring inside the clipped container. */
+.highlight:focus-visible {
+  outline: 2px solid var(--accent-1);
+  outline-offset: -2px;
+}
 
 /* ---------- Tags index + Archives pages ---------- */
 /* These pages already list everything, so the Recently Updated / Trending
@@ -986,6 +992,32 @@ div[class^='language-'] .code-header {
   opacity: 0.85;
 }
 
+/* ---------- Accessibility: skip link ---------- */
+/* Off-screen until focused, then drops into the top-left corner. */
+.skip-link {
+  position: fixed;
+  top: calc(0.5rem + env(safe-area-inset-top));
+  left: calc(0.5rem + env(safe-area-inset-left));
+  z-index: 2000;
+  padding: 0.5rem 0.9rem;
+  color: var(--link-color) !important;
+  background: var(--main-bg);
+  border: 1px solid var(--main-border-color);
+  border-radius: 8px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+  transform: translateY(calc(-100% - 1rem - env(safe-area-inset-top)));
+}
+.skip-link:focus {
+  transform: translateY(0);
+}
+/* Visible confirmation for keyboard users that the skip landed on the content
+   (keyboard-only via :focus-visible, so a mouse click never shows it). */
+#main-content:focus-visible {
+  outline: 2px solid var(--accent-1);
+  outline-offset: -3px;
+  border-radius: 8px;
+}
+
 /* ---------- Footer social icons ---------- */
 /* The shared social-icons row (`social-icons.html`) is otherwise unstyled in
    the footer: raw inline links render tiny (~13px) and gapless. Give them a
@@ -995,10 +1027,15 @@ div[class^='language-'] .code-header {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  gap: 0.85rem;
+  gap: 0.4rem;
   font-size: 1.05rem;
 }
 .footer-socials a {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 1.6rem;
+  min-height: 1.6rem;
   color: var(--text-muted-color) !important;
   transition: color 0.15s ease;
 }


### PR DESCRIPTION
Accessibility polish across the blog, from a heuristic a11y pass. Every fix is verified with axe-core + Playwright on desktop (1280px) and mobile (390px), in light and dark.

## What's fixed

| Issue (axe rule) | Fix |
|---|---|
| Icon-only **back-to-top** has no name (`button-name`) | `aria-label="Back to top"` |
| Icon-only **mobile TOC** trigger has no name (`button-name`) | `aria-label="Table of contents"` |
| **TOC** and **related-posts** `<nav>`s are unlabelled (`landmark-unique`) | `aria-labelledby` their existing headings |
| Wide **code blocks** scroll but aren't keyboard-focusable (`scrollable-region-focusable`) | `tabindex="0"` + a `:focus-visible` ring |
| Heading **permalink** anchors have no name | `aria-label="Permalink to this section"`, icon `aria-hidden` |
| **Footer** social icons below the 24px min target | inline-flex, min `1.6rem` (26×26px) |
| No **skip-to-content** link (WCAG 2.4.1) | first-focusable `Skip to main content` → `#main-content` |
| **Search overlay** had no region/heading | labelled `<section>` + visually-hidden `<h1>` |

`button-name`, `landmark-unique`, `scrollable-region-focusable` and `frame-title` now report **0** on posts and listings (desktop + mobile). The skip link is the first Tab stop and moves focus to `<main>`; code blocks can be focused and arrow-scrolled.

The skip link and back-to-top label required a local override of the theme's `_layouts/default.html` (a faithful copy of the 7.6 layout with only those two additions + `id`/`tabindex` on `<main>`), consistent with the 5 layouts this repo already overrides.

## Skip to main content

First `Tab` reveals a skip link (previously focus went straight to the nav):

| Before | After |
|---|---|
| ![before](https://github.com/CodeMaxx/CodeMaxx.github.io/releases/download/pr-assets/af2-68-skiplink-before.png) | ![after](https://github.com/CodeMaxx/CodeMaxx.github.io/releases/download/pr-assets/af2-68-skiplink-light.png) |

## Keyboard-focusable code blocks

Wide, horizontally-scrolling code is now focusable with a focus ring, so it can be scrolled by keyboard:

| Before | After (light) | After (dark) |
|---|---|---|
| ![before](https://github.com/CodeMaxx/CodeMaxx.github.io/releases/download/pr-assets/af2-68-codefocus-before.png) | ![after light](https://github.com/CodeMaxx/CodeMaxx.github.io/releases/download/pr-assets/af2-68-codefocus-light.png) | ![after dark](https://github.com/CodeMaxx/CodeMaxx.github.io/releases/download/pr-assets/af2-68-codefocus-dark.png) |

## Footer social tap targets

Glyphs look the same; the clickable hit area grew from ~21×25px to **26×26px** (≥24px min). Mobile shown last:

| Before | After | After (mobile) |
|---|---|---|
| ![before](https://github.com/CodeMaxx/CodeMaxx.github.io/releases/download/pr-assets/af2-68-footer-before.png) | ![after](https://github.com/CodeMaxx/CodeMaxx.github.io/releases/download/pr-assets/af2-68-footer-after.png) | ![mobile](https://github.com/CodeMaxx/CodeMaxx.github.io/releases/download/pr-assets/af2-68-footer-mobile.png) |

## Out of scope (left unchanged)

- **Link colour contrast** on body links / tag pills / TOC links — tracked separately.
- **Disqus** thread `link-in-text-block` / `region` — third-party, theme-injected.
- `landmark-one-main` while the search overlay is open — the theme hides `<main>` to show results; the overlay now has a labelled region + heading, which is the scoped fix.
