### PR TITLE
Fix heading hierarchy on listing pages and home

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -125,7 +125,7 @@ refactor: true
 
         <div class="col-md-7">
           <div class="card-body d-flex flex-column">
-            <h1 class="card-title my-2 mt-md-0">
+            <h2 class="card-title my-2 mt-md-0">
               {{ post.title }}
               {% if post.redirect_to %}
                 <i
@@ -134,7 +134,7 @@ refactor: true
                 ></i>
                 <span class="sr-only"> (opens in a new tab)</span>
               {% endif %}
-            </h1>
+            </h2>
 
             <div class="card-text content mt-0 mb-3">
               <p>{% include post-summary.html %}</p>

--- a/_layouts/landing.html
+++ b/_layouts/landing.html
@@ -44,7 +44,7 @@ refactor: true
 
   <!-- ================ WHAT I WRITE ABOUT ================ -->
   <section class="landing-topics">
-    <p class="section-eyebrow">What I write about</p>
+    <h2 class="section-eyebrow">What I write about</h2>
     <div class="topic-grid">
       <a class="topic-card" href="{{ '/blog/' | relative_url }}">
         <i class="fas fa-microchip topic-icon"></i>
@@ -67,7 +67,7 @@ refactor: true
   <!-- ==================== RECENT POSTS ==================== -->
   <section class="landing-recent">
     <div class="section-head">
-      <p class="section-eyebrow mb-0">Recent posts</p>
+      <h2 class="section-eyebrow mb-0">Recent posts</h2>
       <a class="section-more" href="{{ '/blog/' | relative_url }}">All posts &rarr;</a>
     </div>
 

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -1258,7 +1258,10 @@ div[class^='language-'] .code-header {
     font-size: 0.82rem;
     font-weight: 700;
     color: var(--text-muted-color);
+    margin-top: 0;
     margin-bottom: 1.25rem;
+    font-family: inherit;
+    line-height: inherit;
   }
 
   .section-head {


### PR DESCRIPTION
## What & why

On the listing pages, **every post-card title was marked up as an `<h1>`** — 14 on `/blog/`, 37 on `/writeups/` — on top of each page's own title `<h1>`. The two home-page section labels ("What I write about" / "Recent posts") were styled `<p>`s, which also produced an `h1 → h3` skip. Multiple `<h1>`s and skipped levels dilute SEO and break the screen-reader heading outline.

## What changed
- **Listing card titles:** `<h1>` → `<h2>`, so each listing keeps exactly one `<h1>` (its page title).
- **Home section eyebrows:** `<p>` → `<h2>`, with `margin` / `font-family` / `line-height` reset so they render **pixel-identically**.

> [!NOTE]
> This is **purely semantic — there is no visual change to any page.** The heading outline below is the only meaningful before/after.

## Verification
- Each page now has exactly one visible `<h1>`; axe-core heading-order passes.
- Home outline is a clean `H1 → H2 → H3`.
- Rendered pages are pixel-identical before/after (confirmed by screenshot + computed-style diff on the eyebrows).

## Heading outline
![heading outline before and after](https://github.com/CodeMaxx/CodeMaxx.github.io/releases/download/pr-assets/a11y-heading-outline.png)
