### PR TITLE
Add VideoObject schema to the CSec vodcast posts

### DIFF
--- a/_includes/embed/youtube.html
+++ b/_includes/embed/youtube.html
@@ -7,3 +7,20 @@
   allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
   allowfullscreen
 ></iframe>
+{%- comment -%} Opt-in VideoObject schema (post passes `upload_date`) so Google can index video-centric pages. {%- endcomment -%}
+{% if include.upload_date %}
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "VideoObject",
+  "name": {{ include.title | default: page.title | jsonify }},
+  "description": {{ include.description | default: page.description | default: include.title | jsonify }},
+  "thumbnailUrl": "https://i.ytimg.com/vi/{{ include.id }}/hqdefault.jpg",
+  "uploadDate": {{ include.upload_date | jsonify }},
+  {%- if include.duration %}
+  "duration": {{ include.duration | jsonify }},
+  {%- endif %}
+  "embedUrl": "https://www.youtube.com/embed/{{ include.id }}"
+}
+</script>
+{% endif %}

--- a/_posts/2017-08-25-csec-binary-exploitation-1.md
+++ b/_posts/2017-08-25-csec-binary-exploitation-1.md
@@ -22,7 +22,7 @@ Although the school year remains very buzy, I try to give as much time as possib
 
 Presenting the first video from the series (This is my debut video; go easy on me :stuck_out_tongue_winking_eye:) -
 
-{% include embed/youtube.html id='wOJl6N5oiQQ' title='CSec Binary Exploitation vodcast, Episode 1' %}
+{% include embed/youtube.html id='wOJl6N5oiQQ' title='CSec Binary Exploitation vodcast, Episode 1' upload_date='2017-08-22T05:38:01-07:00' duration='PT15M23S' %}
 
 Liked it ??? Didn't like it ????? Let me know!
 

--- a/_posts/2017-11-08-csec-binary-exploitation-2.md
+++ b/_posts/2017-11-08-csec-binary-exploitation-2.md
@@ -22,7 +22,7 @@ In this one I talk about some more advanced exploitation techniques, mitigation 
 Don't miss the demo at the end!
 
 
-{% include embed/youtube.html id='hIIHNUiyw4A' title='CSec Binary Exploitation vodcast, Episode 2' %}
+{% include embed/youtube.html id='hIIHNUiyw4A' title='CSec Binary Exploitation vodcast, Episode 2' upload_date='2017-11-05T03:48:59-08:00' duration='PT32M18S' %}
 
 
 Constructive criticism is much appreciated.


### PR DESCRIPTION
## Problem

Google Search Console flagged **"Video isn't on a watch page"** for `csec-binary-exploitation-1/`, so Google refused to index its embedded YouTube video. Notably, **Episode 2's video *was* indexed** even though the posts are near-identical — the likely difference is video prominence (Ep 2 has a shorter intro, so its player sits higher). Since raising the player is a *content* change (out of scope), this PR pulls the strongest **metadata-only** lever instead.

The pages previously carried **zero video structured data**, forcing Google to infer everything about the video itself.

## Change (metadata only — no visible change)

Extend the local `_includes/embed/youtube.html` override to emit `VideoObject` JSON-LD when a post opts in by passing an `upload_date`. Enabled on both vodcast episodes.

- The rendered page is **byte-for-byte unchanged** for readers — the only addition is an invisible `<script type="application/ld+json">`.
- Opt-in: posts where the video is supplementary (e.g. `Ubisoft-GameJam-Winners/`) do **not** pass `upload_date`, so they emit no schema.
- All values (`uploadDate`, `duration`) were pulled from the real YouTube metadata (`lengthSeconds` 923 → `PT15M23S`, 1938 → `PT32M18S`).

## Emitted JSON-LD (verified valid via production build)

**Episode 1:**
```json
{
  "@context": "https://schema.org",
  "@type": "VideoObject",
  "name": "CSec Binary Exploitation vodcast, Episode 1",
  "description": "Kick-starting IIT Bombay's cybersecurity club with a hands-on buffer overflow vodcast",
  "thumbnailUrl": "https://i.ytimg.com/vi/wOJl6N5oiQQ/hqdefault.jpg",
  "uploadDate": "2017-08-22T05:38:01-07:00",
  "duration": "PT15M23S",
  "embedUrl": "https://www.youtube.com/embed/wOJl6N5oiQQ"
}
```

**Episode 2:** same shape, `hIIHNUiyw4A`, `2017-11-05T03:48:59-08:00`, `PT32M18S`.

## Verification

- Production `JEKYLL_ENV=production` build. Both posts emit exactly one valid `VideoObject` (parsed as JSON). Ubisoft post emits none.
- Both `thumbnailUrl`s return HTTP 200 `image/jpeg` (crawlable).
- Iframe still renders 16:9; page visually unchanged (light + dark spot-checked).
- Rubber-duck review applied: full ISO `uploadDate` timestamps, all dynamic values via `jsonify`, `name` fallback.

## Note / expectations

`VideoObject` improves *eligibility*; Google's classifier makes the final call. After merge + deploy, re-run **URL Inspection → Request Indexing** on the Episode 1 page in Search Console. No visible/UI change, so no before/after screenshots.
