### PR TITLE
Rewrite the About page and drop Resume/CV buttons for now

### DIFF
--- a/_layouts/about.html
+++ b/_layouts/about.html
@@ -5,22 +5,38 @@ layout: default
 {% include lang.html %}
 
 <div class="about">
-  <header class="about-header">
+  <header class="about-head">
     <img
       class="about-avatar"
       src="{{ '/assets/images/avatar.png' | relative_url }}"
-      alt="{{ site.title }}"
-      width="120"
-      height="120"
+      alt="Akash Trehan"
+      width="128"
+      height="128"
     >
-    <div class="about-intro">
-      <h1 class="about-name">{{ site.title }}</h1>
-      <p class="about-role">{{ site.tagline }}</p>
+    <div class="about-head-text">
+      <h1 class="about-name">Hi, I'm Akash</h1>
+      <p class="about-role">Senior Windows Kernel &amp; Security Engineer at Microsoft</p>
       {% include social-icons.html extra_class="about-socials" %}
     </div>
   </header>
 
-  <div class="about-content">
-    {{ content }}
+  <div class="about-body">
+    <p>
+      I'm a security engineer at Microsoft, working deep inside the Windows kernel. Most of my
+      days go into the Secure Kernel, VBS Enclaves, and Secure Runtime Attestation, and sometimes
+      <a href="https://github.com/microsoft/DTrace-on-Windows" target="_blank" rel="noopener">DTrace on Windows</a>
+      too.
+    </p>
+    <p>
+      Before Microsoft I studied Computer Science at IIT Bombay, spent an embarrassing number of
+      nights playing Capture the Flag competitions, spent a summer researching at UC Santa Barbara
+      alongside the Shellphish CTF team, and later worked as a research assistant at Carnegie Mellon
+      University. I got into all of this by trying to break things, and stuck around because I
+      enjoyed building defenses even more.
+    </p>
+    <p>
+      Away from the keyboard I'm usually into cars, scuba diving, or planning the next trip. I'm
+      always happy to talk shop or trade ideas, so feel free to reach out.
+    </p>
   </div>
 </div>

--- a/_layouts/landing.html
+++ b/_layouts/landing.html
@@ -16,15 +16,6 @@ refactor: true
         Microsoft. I write about kernel internals, VBS, and systems security.
       </p>
 
-      <div class="hero-docs">
-        <a class="hero-doc-btn" href="{{ '/assets/AkashTrehan-Resume.pdf' | relative_url }}" target="_blank" rel="noopener">
-          <i class="fas fa-file-lines"></i> Resume
-        </a>
-        <a class="hero-doc-btn" href="{{ '/assets/AkashTrehan-CV.pdf' | relative_url }}" target="_blank" rel="noopener">
-          <i class="fas fa-file-pdf"></i> CV
-        </a>
-      </div>
-
       <div class="hero-follow">
         <p class="hero-follow-label">Connect with me</p>
         {% include social-icons.html extra_class="hero-socials" %}

--- a/_tabs/about.md
+++ b/_tabs/about.md
@@ -5,16 +5,4 @@ order: 7
 title: About
 ---
 
-Akash Trehan is the Founder and Manager of the [Cybersecurity Club](https://www.facebook.com/groups/csec.iitb/) at the Indian Institute of Technology Bombay, taking initiatives to form a community of security enthusiasts and giving talks to spread awareness about the latest research in the area. He is also a member of the [Web & Coding Club](https://www.facebook.com/wncc.iitb), one of the largest college-level programming clubs in India which provides mentorship to students as well as a platform to showcase their skills.
-
-Akash is a rising senior at [IIT Bombay](https://www.iitb.ac.in/), majoring in [Computer Science & Engineering](https://www.cse.iitb.ac.in/). He was awarded the Academic Prize 2015-16 for his exceptional performance and is currently among the top 3 in the Computer Science department. He also ranked 24th amongst 1.5 million students who took JEE Advanced, one of the toughest college admission tests.
-
-When not busy with college work, Akash spends his time participating in Capture the Flag competitions, where his favourite categories are Reverse Engineering and Pwning. He is primarily interested in Software & Systems security, Network security but likes to take on any challenge he finds interesting. He is very passionate about computer security and is mostly self-taught in the area. He hopes to do some ground-breaking security research later in his life. Last summer he got the amazing opportunity to research under [Prof. Giovanni Vigna](https://www.cs.ucsb.edu/~vigna/) and [Prof. Christopher Kruegel](https://www.cs.ucsb.edu/~chris/) at the University of California, Santa Barbara and play CTFs with the famous team [Shellphish](https://shellphish.net/cgc/)!
-
-Not only does he love breaking software but also building them. Akash, in his freshman year, formed the [Ferozepurwale](https://github.com/Ferozepurwale/) hackathon team with two of his friends, Nihal and Arpan. Together they have won several prizes including- Ubisoft GameJam 1st place, Yahoo! Japan Most Creative Hack, Microsoft Code.Fun.Do Showcase Finalist, Lenovo GameJam, Kandy Hackathon, Hack InOut blockchain track 1st prize among others. They've also developed apps and websites for their university. Akash is also an open-source enthusiast and contributes to software like OWASP ZSC, SymEngine on Github where he goes by the handle '[CodeMaxx](https://github.com/CodeMaxx)'.
-
-Akash loves to think, read, listen to and analyze new ideas and opinions. He firmly believes that creativity, imagination, and ideas can change the world. He watches every TED talks he comes across and dreams of giving one himself someday.
-
-In his spare time, you will find him listening to Music or watching his all time favourite show - Impractical Jokers.
-
-Akash is always interested in collaborating on projects and discussing ideas. <a href="#" onclick="location.href='mailto:' + 'me' + '@' + 'akashtrehan.com'; return false;">Email him</a> if you'd like to get in touch.
+<!-- The About page content and layout live in _layouts/about.html (mirrors the landing-page pattern in _layouts/landing.html). Edit the copy there. -->

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -327,73 +327,80 @@ $tn-max: 1140px;
 
 /* ---------- About page ---------- */
 .about {
-  max-width: 820px;
+  max-width: 720px;
   margin: 0 auto;
   padding-top: 0.5rem;
 }
-.about-header {
+
+/* ---------- Header ---------- */
+.about-head {
   display: flex;
   align-items: center;
-  gap: 1.5rem;
+  gap: 1.6rem;
   padding-bottom: 1.75rem;
   margin-bottom: 1.75rem;
   border-bottom: 1px solid var(--main-border-color, rgba(0, 0, 0, 0.08));
 }
 .about-avatar {
-  width: 120px;
-  height: 120px;
+  width: 128px;
+  height: 128px;
   border-radius: 50%;
   object-fit: cover;
   flex-shrink: 0;
-  box-shadow: 0 10px 30px rgba(29, 58, 90, 0.2);
+  box-shadow: 0 10px 30px rgba(29, 58, 90, 0.22);
 }
 .about-name {
   font-size: 1.9rem;
   font-weight: 700;
   letter-spacing: -0.02em;
-  margin-bottom: 0.25rem;
+  margin-bottom: 0.3rem;
 }
 .about-role {
   color: var(--text-muted-color);
-  font-size: 1rem;
-  margin-bottom: 0.9rem;
+  font-size: 1.02rem;
+  margin-bottom: 1rem;
+}
+/* ---------- Body ---------- */
+.about-body {
+  font-size: 1.06rem;
+  line-height: 1.75;
+}
+.about-body p {
+  margin-bottom: 1.15rem;
 }
 .about-socials {
   display: flex;
-  gap: 0.55rem;
+  flex-wrap: wrap;
+  gap: 0.6rem;
 }
 .about-socials a {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 38px;
-  height: 38px;
-  border-radius: 10px;
-  font-size: 0.95rem;
+  width: 40px;
+  height: 40px;
+  border-radius: 11px;
+  font-size: 1rem;
   color: var(--heading-color) !important;
   background: var(--card-bg);
   border: 1px solid var(--card-border-color, rgba(0, 0, 0, 0.08));
-  transition: transform 0.15s ease, color 0.15s ease, background 0.15s ease;
+  transition: transform 0.15s ease, box-shadow 0.2s ease, color 0.15s ease, background 0.15s ease;
 }
 .about-socials a:hover {
   transform: translateY(-2px);
   color: #fff !important;
   background: var(--accent-grad);
   border-color: transparent;
-}
-.about-content {
-  font-size: 1.05rem;
-  line-height: 1.75;
-}
-.about-content p {
-  margin-bottom: 1.15rem;
+  box-shadow: 0 8px 20px var(--accent-soft);
 }
 
-@media (max-width: 600px) {
-  .about-header {
+/* ---------- Responsive ---------- */
+@media (max-width: 560px) {
+  .about-head {
     flex-direction: column;
     text-align: center;
     align-items: center;
+    gap: 1.1rem;
   }
   .about-socials {
     justify-content: center;


### PR DESCRIPTION
## What

Refreshes the **About** page and temporarily removes the Resume/CV buttons.

- **About page:** replaced the outdated, college-era bio with a short, current About — a compact header (round avatar, name, role, and social links) plus three short paragraphs covering current work (Secure Kernel, VBS Enclaves, Secure Runtime Attestation, and [DTrace on Windows](https://github.com/microsoft/DTrace-on-Windows)), background (IIT Bombay, CTFs, UC Santa Barbara / Shellphish, Carnegie Mellon), and interests. Social links now live in the header (email was previously duplicated between a button and the icon row).
- **Home + About:** removed the Resume and CV buttons for now. Their CSS is left in place so they're easy to re-add later.
- The About markup + copy now lives in `_layouts/about.html` (mirrors the landing-page pattern); `_tabs/about.md` is front matter only.

This is a first draft to refresh the live site. A personal section (cars / scuba / travel with photos) and an end-of-post author bio box will follow separately.

## Before / After

### About page

<table>
<tr><th>Before (live site)</th><th>After</th></tr>
<tr>
<td><img src="https://github.com/CodeMaxx/CodeMaxx.github.io/releases/download/pr-assets/af2-3-pr-before-about.png" width="420"></td>
<td><img src="https://github.com/CodeMaxx/CodeMaxx.github.io/releases/download/pr-assets/af2-3-pr-after-about.png" width="420"></td>
</tr>
</table>

After — mobile (390px):

<img src="https://github.com/CodeMaxx/CodeMaxx.github.io/releases/download/pr-assets/af2-3-pr-after-about-mobile.png" width="260">

### Home hero — Resume/CV removed (outlined in red in the "before")

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://github.com/CodeMaxx/CodeMaxx.github.io/releases/download/pr-assets/af2-3-pr-before-home-hero.png" width="420"></td>
<td><img src="https://github.com/CodeMaxx/CodeMaxx.github.io/releases/download/pr-assets/af2-3-pr-after-home-hero.png" width="420"></td>
</tr>
</table>

## Notes

- Verified with a clean `bundle exec jekyll build` and an adversarial review: one visible `<h1>`, working links, labeled social icons, balanced SCSS, LF line endings.
- Renders correctly in light + dark and on mobile.
